### PR TITLE
Alphabet-Datenerfassung (A–Z, mehrere Takes pro Person) + Recording-Pipeline-Fixes

### DIFF
--- a/GestureRecognition/demo.py
+++ b/GestureRecognition/demo.py
@@ -7,9 +7,18 @@ def run(parser: argparse.ArgumentParser):
     parser.add_argument("--recorder.file", action="store")
     parser.add_argument("--engine.singlestep", action="store_true", default=False)
     parser.add_argument("--webcam.width", required=False)
-    modules = [
-        ConfigParser(parser),
-        # Webcam(),
+
+    # Mode vorab auslesen, um die Modulliste passend zusammenzustellen.
+    args, _ = parser.parse_known_args()
+    mode = args.mode or ""
+
+    modules = [ConfigParser(parser)]
+    # Im Replay-Modus liefern die Replay-Wrapper die Daten aus einer Aufnahme,
+    # eine Webcam ist dann nicht noetig (und wuerde unnoetig die Kamera oeffnen).
+    # Fuer Record- und Live-Betrieb wird die Webcam als Bildquelle gebraucht.
+    if "replay" not in mode:
+        modules.append(Webcam())
+    modules += [
         HandDetector(),
         TrailMarker(),
         Preprocessor(),

--- a/GestureRecognition/labeling.py
+++ b/GestureRecognition/labeling.py
@@ -419,15 +419,50 @@ def dataset_building(
         recordings_dir, finger_idx=finger_idx, min_length=min_length, max_jump=max_jump
     )
 
+    # Sequenzen sammeln und dabei solche mit NaN-Werten ueberspringen.
+    # NaN entsteht bei Frames ohne erkannte Hand mitten in der Aufnahme.
+    # Solche Werte landen sonst ungefiltert im Trainings-Array, womit das
+    # HMM-Training nicht zurechtkommt.
     sequences: list[np.ndarray] = []
     labels: list[str] = []
+    nan_skipped: dict[str, int] = defaultdict(int)
     for label, trajectories in dataset.items():
         for traj in trajectories:
+            if np.isnan(traj).any():
+                nan_skipped[label] += 1
+                continue
             sequences.append(traj)
             labels.append(label)
 
+    if nan_skipped:
+        total_skipped = sum(nan_skipped.values())
+        logger.info(
+            "%d Sequenz(en) wegen NaN-Werten uebersprungen: %s",
+            total_skipped,
+            dict(nan_skipped),
+        )
+
     if not sequences:
         raise ValueError("Keine gueltigen Aufnahmen gefunden.")
+
+    # Stratifizierter Split braucht pro Klasse mindestens zwei Aufnahmen,
+    # damit jede Klasse in Train- UND Test-Set vertreten sein kann.
+    # Sonst bricht train_test_split mit einer schwer verstaendlichen
+    # Meldung ab -- deshalb hier vorab pruefen und klar melden.
+    class_counts = Counter(labels)
+    too_few = {
+        label: count for label, count in class_counts.items() if count < 2
+    }
+    if too_few:
+        details = ", ".join(
+            f"'{label}': {count} Aufnahme(n)" for label, count in sorted(too_few.items())
+        )
+        raise ValueError(
+            "Fuer einen stratifizierten Train/Test-Split werden pro Klasse "
+            "mindestens 2 gueltige Aufnahmen benoetigt. Zu wenige Aufnahmen "
+            f"bei: {details}. Bitte mehr Aufnahmen erstellen oder die "
+            "Bereinigungs-Parameter (min_length, max_jump) lockern."
+        )
 
     indices = np.arange(len(sequences))
     train_idx, test_idx = train_test_split(

--- a/GestureRecognition/labeling.py
+++ b/GestureRecognition/labeling.py
@@ -7,7 +7,8 @@ import pickle
 import logging
 import numpy as np
 from pathlib import Path
-from collections import defaultdict
+from collections import Counter, defaultdict
+from sklearn.model_selection import train_test_split
 
 logger = logging.getLogger(__name__)
 
@@ -353,73 +354,121 @@ def data_labeling(times: int, label: str):
 
 
 
-def dataset_building(output_path):
+def dataset_building(
+    output_path: str | Path,
+    recordings_dir: str | Path = "recordings",
+    finger_idx: int = 8,
+    min_length: int = 15,
+    max_jump: float = 0.15,
+    test_size: float = 0.2,
+    random_state: int = 42,
+) -> dict:
     """
-    TODO: dataset_building: Trainingsdatensatz aus aufgenommenen Gesten erstellen
+    Baut aus den Rohaufnahmen einen Trainingsdatensatz für den HMMClassifier.
 
-    Ziel:
-    -----
-    Implementiere eine Funktion, die alle aufgenommenen Daten lädt,
-    verarbeitet und in eine Form bringt, die von eurem
-    Hidden-Markov-Modell (HMM) Classifier verwendet werden kann.
+    Lädt und bereinigt alle Aufnahmen über :func:`clean_recordings`, fasst
+    sie zu ``X``/``y``/``lengths``-Arrays zusammen (das Format, das
+    :meth:`HMMClassifier.fit` erwartet) und teilt sie auf Sequenz-Ebene in
+    Train- und Test-Set.
 
-    Anforderungen / Ideen:
-    ----------------------
+    Sequenz-Level-Split (Vermeidung von Data Leakage)
+    --------------------------------------------------
+    Jede Aufnahme ist eine ganze Geste (Sequenz von Frames). Würde man
+    stattdessen einzelne Frames zufällig auf Train/Test verteilen, könnten
+    Frames derselben Geste in beiden Sets landen — das Modell würde dann
+    quasi "auswendig lernen" und die Testgenauigkeit wäre künstlich hoch.
+    Deshalb wird hier auf Höhe ganzer Aufnahmen gesplittet: Jede Sequenz
+    landet komplett in genau einem der beiden Sets.
 
-    1. Daten laden
-
-       - Durchsuche deinen Trainingsdaten-Ordner
-       - Organisiere Daten nach Labels
-
-    2. Feature-Extraktion / Preprocessing
-
-       - Überlege:
-         - Welche Features braucht dein Modell?
-         - Wie transformierst du die Rohdaten sinnvoll?
-       - Wende eine konsistente Verarbeitung auf alle Sequenzen an
-
-    3. Umgang mit Sequenzen
-
-       - Daten sind zeitliche Sequenzen
-       - Achte auf:
-         - Unterschiedliche Längen
-         - Konsistente Struktur
-
-    4. Validierung
-
-       - Entferne unbrauchbare Daten
-         (z. B. zu kurze oder fehlerhafte Sequenzen)
-
-    5. Ausgabeformat
-
-       - Baue den Datensatz so, dass dein HMM direkt damit arbeiten kann
-       - Das Format sollst du selbst definieren
-
-    .. note::
-
-       Es gibt hier keine vorgegebene „richtige“ Lösung.
-       Wichtig ist, dass dein Datensatz konsistent und nutzbar ist.
-
-    .. tip::
-
-       Denke wie ein System-Designer:
-       Wie müssen Daten aussehen, damit Training und Inferenz sauber funktionieren?
-
-    .. warning::
-
-       Inkonsistente Datenstrukturen sind eine der häufigsten Fehlerquellen
-       beim Training von Sequenzmodellen.
-
-    Erweiterung (optional):
-    -----------------------
-
-    - Normalisierung der Daten
-    - Datenaugmentation
-    - Debug-Ausgaben oder Visualisierung
+    Stratifizierung
+    ----------------
+    ``stratify=labels`` sorgt dafür, dass Train- und Test-Set für jede
+    Klasse den gleichen Anteil an Aufnahmen enthalten (z.B. bei 10
+    Aufnahmen und ``test_size=0.2`` landen pro Klasse 2 im Test-Set).
+    Ohne Stratifizierung könnte eine Klasse bei wenigen Aufnahmen rein
+    zufällig komplett im Train- oder Test-Set landen.
 
     Parameters
     ----------
-    output_path : Path or str
-        Zielpfad für den erzeugten Trainingsdatensatz.
+    output_path : str or Path
+        Zielpfad für die erzeugte Pickle-Datei.
+    recordings_dir : str or Path
+        Verzeichnis mit den Rohaufnahmen (``recordings/<label>/*.pkl``).
+    finger_idx : int
+        MediaPipe-Landmark-Index des verfolgten Fingers.
+    min_length : int
+        Minimale Sequenzlänge, siehe :func:`clean_recordings`.
+    max_jump : float
+        Maximaler Frame-zu-Frame-Sprung, siehe :func:`clean_recordings`.
+    test_size : float
+        Anteil der Aufnahmen pro Klasse, der ins Test-Set wandert.
+    random_state : int
+        Seed für den Split, für Reproduzierbarkeit.
+
+    Returns
+    -------
+    dict
+        Dictionary mit den Schlüsseln ``X_train``, ``y_train``,
+        ``lengths_train``, ``X_test``, ``y_test``, ``lengths_test`` sowie
+        ``classes`` (sortierte Liste aller Klassenlabels). ``X_*`` sind
+        konkatenierte Feature-Arrays, ``lengths_*`` enthält die Länge jeder
+        einzelnen Sequenz darin — direkt nutzbar für
+        ``HMMClassifier.fit(X_train, y_train, lengths_train)``.
     """
-    pass
+    dataset = clean_recordings(
+        recordings_dir, finger_idx=finger_idx, min_length=min_length, max_jump=max_jump
+    )
+
+    sequences: list[np.ndarray] = []
+    labels: list[str] = []
+    for label, trajectories in dataset.items():
+        for traj in trajectories:
+            sequences.append(traj)
+            labels.append(label)
+
+    if not sequences:
+        raise ValueError("Keine gueltigen Aufnahmen gefunden.")
+
+    indices = np.arange(len(sequences))
+    train_idx, test_idx = train_test_split(
+        indices, test_size=test_size, stratify=labels, random_state=random_state
+    )
+
+    def _build_split(idx_list):
+        seqs = [sequences[i] for i in idx_list]
+        labs = [labels[i] for i in idx_list]
+        lengths = [len(seq) for seq in seqs]
+        X = np.vstack(seqs)
+        y = np.array(labs)
+        return X, y, lengths
+
+    X_train, y_train, lengths_train = _build_split(train_idx)
+    X_test, y_test, lengths_test = _build_split(test_idx)
+
+    train_counts = Counter(y_train.tolist())
+    test_counts = Counter(y_test.tolist())
+    for label in sorted(dataset.keys()):
+        logger.info(
+            "[%s] train: %d, test: %d",
+            label,
+            train_counts.get(label, 0),
+            test_counts.get(label, 0),
+        )
+
+    result = {
+        "X_train": X_train,
+        "y_train": y_train,
+        "lengths_train": lengths_train,
+        "X_test": X_test,
+        "y_test": y_test,
+        "lengths_test": lengths_test,
+        "classes": sorted(dataset.keys()),
+    }
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "wb") as f:
+        pickle.dump(result, f)
+
+    logger.info("Datensatz gespeichert: %s", output_path)
+    return result

--- a/GestureRecognition/labeling.py
+++ b/GestureRecognition/labeling.py
@@ -251,6 +251,51 @@ def _next_recording_index(label_dir: str) -> int:
     return i
 
 
+def _record_one_take() -> str | None:
+    """
+    Nimmt eine einzelne Geste auf und gibt den Pfad der Temp-Datei zurueck.
+
+    Startet ``main.py`` im Record-Modus als Subprocess und lenkt die Aufnahme
+    in eine temporaere Datei. Die leere Temp-Datei wird vorher geloescht, damit
+    ihr blosses Vorhandensein nach dem Subprocess bedeutet: "Aufnahme war
+    erfolgreich".
+
+    Der Aufrufer ist dafuer verantwortlich, die zurueckgegebene Temp-Datei
+    entweder an ihren Zielort zu verschieben oder zu loeschen.
+
+    Returns
+    -------
+    str or None
+        Pfad zur Temp-Datei mit der Aufnahme, oder ``None`` wenn keine
+        Aufnahme entstanden ist (z. B. bei einem Crash).
+    """
+    # Temporaere Datei fuer diese eine Aufnahme erstellen.
+    # SignalHub schreibt die Aufnahme erst beim sauberen Beenden in diese Datei.
+    # Wir loeschen die leere Temp-Datei wieder, damit ihr blosses Vorhandensein
+    # spaeter bedeutet: "Aufnahme war erfolgreich".
+    fd, temp_file = tempfile.mkstemp(suffix=".pkl")
+    os.close(fd)
+    os.remove(temp_file)
+
+    # main.py als Subprocess starten und die Aufnahme in die Temp-Datei lenken.
+    # --mode record sorgt dafuer, dass aufgenommen wird.
+    cmd = [
+        sys.executable,
+        "main.py",
+        "--mode",
+        "record",
+        "--recorder.file",
+        temp_file,
+    ]
+    subprocess.run(cmd)
+
+    # Crash-Schutz: Wenn keine Datei entstanden ist, ist beim Aufnehmen
+    # etwas schiefgelaufen.
+    if not os.path.exists(temp_file):
+        return None
+    return temp_file
+
+
 def data_labeling(times: int, label: str):
     """
     Aufnahme-Workflow fuer eigene Trainingsdaten.
@@ -292,33 +337,16 @@ def data_labeling(times: int, label: str):
         print(f"--- Aufnahme {saved + 1} von {times} (Label: {label}) ---")
         input("Druecke ENTER, um die Aufnahme zu starten ...")
 
-        # Temporaere Datei fuer diese eine Aufnahme erstellen.
-        # SignalHub schreibt die Aufnahme erst beim sauberen Beenden in diese Datei.
-        # Wir loeschen die leere Temp-Datei wieder, damit ihr blosses Vorhandensein
-        # spaeter bedeutet: "Aufnahme war erfolgreich".
-        fd, temp_file = tempfile.mkstemp(suffix=".pkl")
-        os.close(fd)
-        os.remove(temp_file)
+        # Eine einzelne Aufnahme machen (Temp-Datei mit Crash-Schutz).
+        temp_file = _record_one_take()
+
+        # Crash-Schutz: Wenn keine Datei entstanden ist, ist beim Aufnehmen
+        # etwas schiefgelaufen. Wir speichern dann nichts und versuchen es erneut.
+        if temp_file is None:
+            print("Es wurde keine Aufnahme erzeugt. Bitte erneut versuchen.")
+            continue
 
         try:
-            # main.py als Subprocess starten und die Aufnahme in die Temp-Datei lenken.
-            # --mode record sorgt dafuer, dass aufgenommen wird.
-            cmd = [
-                sys.executable,
-                "main.py",
-                "--mode",
-                "record",
-                "--recorder.file",
-                temp_file,
-            ]
-            subprocess.run(cmd)
-
-            # Crash-Schutz: Wenn keine Datei entstanden ist, ist beim Aufnehmen
-            # etwas schiefgelaufen. Wir speichern dann nichts und versuchen es erneut.
-            if not os.path.exists(temp_file):
-                print("Es wurde keine Aufnahme erzeugt. Bitte erneut versuchen.")
-                continue
-
             # Benutzer entscheiden lassen, was mit der Aufnahme passiert
             print("Was soll mit der Aufnahme passieren?")
             print("  [s] speichern")
@@ -352,6 +380,126 @@ def data_labeling(times: int, label: str):
     print(f"Fertig. {saved} Aufnahme(n) fuer Label '{label}' gespeichert.")
 
 
+# Buchstaben A-Z, die im Team-Workflow aufgenommen werden.
+ALPHABET = [chr(c) for c in range(ord("A"), ord("Z") + 1)]
+
+
+def collect_alphabet(person: str, recordings_dir: str | Path = "recordings"):
+    """
+    Gefuehrter Aufnahme-Durchlauf: jeder Buchstabe A-Z genau einmal pro Person.
+
+    Fuehrt eine Person automatisch durch das komplette Alphabet und nimmt pro
+    Buchstabe genau eine Geste auf. Die Aufnahmen landen direkt unter
+    ``recordings/<Buchstabe>/<Buchstabe>-<person>.pkl`` -- also genau dort, wo
+    :func:`dataset_building` standardmaessig liest. Damit fliessen die neuen
+    Aufnahmen ohne weitere Schritte ins Training.
+
+    Resume-Faehigkeit
+    -----------------
+    Buchstaben, fuer die diese Person bereits eine Datei hat, werden
+    uebersprungen. Der Durchlauf kann also jederzeit abgebrochen und spaeter
+    fortgesetzt werden, ohne etwas zu ueberschreiben.
+
+    Parameters
+    ----------
+    person : str
+        Name oder Kuerzel der aufnehmenden Person (z. B. "arian"). Wird Teil
+        des Dateinamens, damit die Diversitaet nachvollziehbar bleibt und keine
+        Doppelaufnahmen derselben Person entstehen.
+    recordings_dir : str or Path
+        Zielverzeichnis mit den Label-Unterordnern (Standard: ``recordings``).
+    """
+    # Personennamen bereinigen und auf dateinamen-taugliche Zeichen pruefen.
+    person = person.strip()
+    if not person:
+        raise ValueError("Bitte einen nicht-leeren Namen / ein Kuerzel angeben.")
+    if any(c in person for c in r'/\: '):
+        raise ValueError(
+            f"Ungueltiger Name '{person}': keine Leerzeichen, Slashes oder "
+            "Doppelpunkte erlauben (wird Teil des Dateinamens)."
+        )
+
+    recordings_dir = Path(recordings_dir)
+
+    # Kurze Anleitung ausgeben
+    print("=" * 50)
+    print(f"Alphabet-Aufnahme fuer: {person}")
+    print(f"Es werden alle {len(ALPHABET)} Buchstaben (A-Z) je einmal aufgenommen.")
+    print("Bereits aufgenommene Buchstaben werden uebersprungen.")
+    print("Ablauf pro Buchstabe:")
+    print("  1. ENTER druecken, dann fuehrt sich das Aufnahme-Fenster.")
+    print("  2. Geste ausfuehren und das Fenster schliessen.")
+    print("  3. Danach entscheiden: speichern / verwerfen / abbrechen.")
+    print("=" * 50)
+
+    saved = 0
+    skipped = 0
+
+    for i, letter in enumerate(ALPHABET, start=1):
+        label_dir = recordings_dir / letter
+        dest = label_dir / f"{letter}-{person}.pkl"
+
+        # Resume: schon vorhandene Aufnahme dieser Person ueberspringen.
+        if dest.exists():
+            print(f"[{i}/{len(ALPHABET)}] {letter}: bereits vorhanden -> uebersprungen")
+            skipped += 1
+            continue
+
+        label_dir.mkdir(parents=True, exist_ok=True)
+
+        # Pro Buchstabe so lange anbieten, bis gespeichert, uebersprungen
+        # oder der ganze Vorgang abgebrochen wird.
+        done = False
+        aborted = False
+        while not done:
+            print()
+            print("#" * 50)
+            print(f"#   Buchstabe:  {letter}        [{i}/{len(ALPHABET)}]")
+            print("#" * 50)
+            input("Druecke ENTER, um die Aufnahme zu starten ...")
+
+            temp_file = _record_one_take()
+            if temp_file is None:
+                print("Es wurde keine Aufnahme erzeugt. Bitte erneut versuchen.")
+                continue
+
+            try:
+                print("Was soll mit der Aufnahme passieren?")
+                print("  [s] speichern")
+                print("  [v] verwerfen (Buchstabe wiederholen)")
+                print("  [a] abbrechen (ganzen Durchlauf beenden)")
+                choice = input("Deine Wahl: ").strip().lower()
+
+                if choice == "s":
+                    shutil.move(temp_file, dest)
+                    saved += 1
+                    print(f"Gespeichert: {dest}")
+                    done = True
+                elif choice == "a":
+                    print("Durchlauf abgebrochen.")
+                    aborted = True
+                    done = True
+                else:
+                    print("Aufnahme verworfen.")
+            finally:
+                # Aufraeumen: eine evtl. noch vorhandene Temp-Datei loeschen.
+                if os.path.exists(temp_file):
+                    os.remove(temp_file)
+
+        if aborted:
+            break
+
+    # Abschluss: wie viele der 26 Buchstaben hat diese Person nun insgesamt?
+    have = sum(
+        1 for letter in ALPHABET if (recordings_dir / letter / f"{letter}-{person}.pkl").exists()
+    )
+    print()
+    print("=" * 50)
+    print(f"Fertig. Neu gespeichert: {saved}, uebersprungen: {skipped}.")
+    print(f"'{person}' hat jetzt {have}/{len(ALPHABET)} Buchstaben aufgenommen.")
+    if have < len(ALPHABET):
+        print("Tipp: Skript erneut starten, um die fehlenden Buchstaben zu ergaenzen.")
+    print("=" * 50)
 
 
 def dataset_building(

--- a/GestureRecognition/labeling.py
+++ b/GestureRecognition/labeling.py
@@ -384,31 +384,65 @@ def data_labeling(times: int, label: str):
 ALPHABET = [chr(c) for c in range(ord("A"), ord("Z") + 1)]
 
 
-def collect_alphabet(person: str, recordings_dir: str | Path = "recordings"):
+def _person_takes(label_dir: Path, letter: str, person: str) -> int:
     """
-    Gefuehrter Aufnahme-Durchlauf: jeder Buchstabe A-Z genau einmal pro Person.
+    Zaehlt, wie viele Takes diese Person fuer einen Buchstaben schon hat.
+
+    Beruecksichtigt nummerierte Takes (``<L>-<person>-<n>.pkl``) und – aus
+    Abwaertskompatibilitaet – die alte Einzeldatei (``<L>-<person>.pkl``).
+    """
+    numbered = list(label_dir.glob(f"{letter}-{person}-*.pkl"))
+    legacy = label_dir / f"{letter}-{person}.pkl"
+    return len(numbered) + (1 if legacy.exists() else 0)
+
+
+def _next_person_take_path(label_dir: Path, letter: str, person: str) -> Path:
+    """
+    Findet den naechsten freien Take-Pfad ``<L>-<person>-<n>.pkl``.
+
+    Zaehlt ab 1 hoch, bis ein noch nicht vergebener Name gefunden ist, damit
+    keine bestehende Aufnahme ueberschrieben wird.
+    """
+    n = 1
+    while (label_dir / f"{letter}-{person}-{n}.pkl").exists():
+        n += 1
+    return label_dir / f"{letter}-{person}-{n}.pkl"
+
+
+def collect_alphabet(
+    person: str,
+    times: int = 15,
+    recordings_dir: str | Path = "recordings",
+):
+    """
+    Gefuehrter Aufnahme-Durchlauf: jeder Buchstabe A-Z mehrfach pro Person.
 
     Fuehrt eine Person automatisch durch das komplette Alphabet und nimmt pro
-    Buchstabe genau eine Geste auf. Die Aufnahmen landen direkt unter
-    ``recordings/<Buchstabe>/<Buchstabe>-<person>.pkl`` -- also genau dort, wo
-    :func:`dataset_building` standardmaessig liest. Damit fliessen die neuen
-    Aufnahmen ohne weitere Schritte ins Training.
+    Buchstabe ``times`` Gesten auf. Die Aufnahmen landen direkt unter
+    ``recordings/<Buchstabe>/<Buchstabe>-<person>-<n>.pkl`` -- also genau dort,
+    wo :func:`dataset_building` standardmaessig liest (es liest alle ``*.pkl``
+    eines Ordners). Damit fliessen die neuen Aufnahmen ohne weitere Schritte
+    ins Training.
 
     Resume-Faehigkeit
     -----------------
-    Buchstaben, fuer die diese Person bereits eine Datei hat, werden
-    uebersprungen. Der Durchlauf kann also jederzeit abgebrochen und spaeter
-    fortgesetzt werden, ohne etwas zu ueberschreiben.
+    Pro Buchstabe wird gezaehlt, wie viele Takes diese Person bereits hat;
+    aufgenommen wird nur, bis ``times`` erreicht ist. Der Durchlauf kann also
+    jederzeit abgebrochen und spaeter fortgesetzt werden, ohne etwas zu
+    ueberschreiben.
 
     Parameters
     ----------
     person : str
         Name oder Kuerzel der aufnehmenden Person (z. B. "arian"). Wird Teil
-        des Dateinamens, damit die Diversitaet nachvollziehbar bleibt und keine
-        Doppelaufnahmen derselben Person entstehen.
+        des Dateinamens, damit die Diversitaet nachvollziehbar bleibt.
+    times : int
+        Wie viele Takes pro Buchstabe diese Person aufnehmen soll (Standard: 15).
     recordings_dir : str or Path
         Zielverzeichnis mit den Label-Unterordnern (Standard: ``recordings``).
     """
+    if times < 1:
+        raise ValueError(f"times muss >= 1 sein, war {times}.")
     # Personennamen bereinigen und auf dateinamen-taugliche Zeichen pruefen.
     person = person.strip()
     if not person:
@@ -424,8 +458,8 @@ def collect_alphabet(person: str, recordings_dir: str | Path = "recordings"):
     # Kurze Anleitung ausgeben
     print("=" * 50)
     print(f"Alphabet-Aufnahme fuer: {person}")
-    print(f"Es werden alle {len(ALPHABET)} Buchstaben (A-Z) je einmal aufgenommen.")
-    print("Bereits aufgenommene Buchstaben werden uebersprungen.")
+    print(f"Es werden alle {len(ALPHABET)} Buchstaben (A-Z) je {times}x aufgenommen.")
+    print("Bereits aufgenommene Takes werden uebersprungen.")
     print("Ablauf pro Buchstabe:")
     print("  1. ENTER druecken, dann fuehrt sich das Aufnahme-Fenster.")
     print("  2. Geste ausfuehren und das Fenster schliessen.")
@@ -435,26 +469,31 @@ def collect_alphabet(person: str, recordings_dir: str | Path = "recordings"):
     saved = 0
     skipped = 0
 
+    aborted = False
     for i, letter in enumerate(ALPHABET, start=1):
         label_dir = recordings_dir / letter
-        dest = label_dir / f"{letter}-{person}.pkl"
+        label_dir.mkdir(parents=True, exist_ok=True)
 
-        # Resume: schon vorhandene Aufnahme dieser Person ueberspringen.
-        if dest.exists():
-            print(f"[{i}/{len(ALPHABET)}] {letter}: bereits vorhanden -> uebersprungen")
+        # Resume: schon vorhandene Takes dieser Person mitzaehlen.
+        have_letter = _person_takes(label_dir, letter, person)
+        if have_letter >= times:
+            print(
+                f"[{i}/{len(ALPHABET)}] {letter}: bereits {have_letter}/{times} "
+                "-> uebersprungen"
+            )
             skipped += 1
             continue
 
-        label_dir.mkdir(parents=True, exist_ok=True)
-
-        # Pro Buchstabe so lange anbieten, bis gespeichert, uebersprungen
-        # oder der ganze Vorgang abgebrochen wird.
-        done = False
-        aborted = False
-        while not done:
+        # Pro Buchstabe so lange aufnehmen, bis times Takes erreicht sind
+        # (oder der ganze Vorgang abgebrochen wird).
+        while have_letter < times and not aborted:
+            take_no = have_letter + 1
             print()
             print("#" * 50)
-            print(f"#   Buchstabe:  {letter}        [{i}/{len(ALPHABET)}]")
+            print(
+                f"#   Buchstabe:  {letter}   Take {take_no}/{times}   "
+                f"[{i}/{len(ALPHABET)}]"
+            )
             print("#" * 50)
             input("Druecke ENTER, um die Aufnahme zu starten ...")
 
@@ -466,19 +505,19 @@ def collect_alphabet(person: str, recordings_dir: str | Path = "recordings"):
             try:
                 print("Was soll mit der Aufnahme passieren?")
                 print("  [s] speichern")
-                print("  [v] verwerfen (Buchstabe wiederholen)")
+                print("  [v] verwerfen (Take wiederholen)")
                 print("  [a] abbrechen (ganzen Durchlauf beenden)")
                 choice = input("Deine Wahl: ").strip().lower()
 
                 if choice == "s":
+                    dest = _next_person_take_path(label_dir, letter, person)
                     shutil.move(temp_file, dest)
                     saved += 1
+                    have_letter += 1
                     print(f"Gespeichert: {dest}")
-                    done = True
                 elif choice == "a":
                     print("Durchlauf abgebrochen.")
                     aborted = True
-                    done = True
                 else:
                     print("Aufnahme verworfen.")
             finally:
@@ -489,16 +528,20 @@ def collect_alphabet(person: str, recordings_dir: str | Path = "recordings"):
         if aborted:
             break
 
-    # Abschluss: wie viele der 26 Buchstaben hat diese Person nun insgesamt?
-    have = sum(
-        1 for letter in ALPHABET if (recordings_dir / letter / f"{letter}-{person}.pkl").exists()
+    # Abschluss: wie viele Buchstaben hat diese Person nun vollstaendig (times Takes)?
+    complete = sum(
+        1 for letter in ALPHABET
+        if _person_takes(recordings_dir / letter, letter, person) >= times
     )
     print()
     print("=" * 50)
     print(f"Fertig. Neu gespeichert: {saved}, uebersprungen: {skipped}.")
-    print(f"'{person}' hat jetzt {have}/{len(ALPHABET)} Buchstaben aufgenommen.")
-    if have < len(ALPHABET):
-        print("Tipp: Skript erneut starten, um die fehlenden Buchstaben zu ergaenzen.")
+    print(
+        f"'{person}' hat jetzt {complete}/{len(ALPHABET)} Buchstaben "
+        f"vollstaendig ({times} Takes)."
+    )
+    if complete < len(ALPHABET):
+        print("Tipp: Skript erneut starten, um die fehlenden Takes zu ergaenzen.")
     print("=" * 50)
 
 

--- a/GestureRecognition/modules/preprocessor.py
+++ b/GestureRecognition/modules/preprocessor.py
@@ -110,18 +110,18 @@ class Preprocessor(Module):
         # First, I read the configuration values from the config signal.
         # I use get_nested_key to access nested config values safely.
         # The finger_index specifies which finger landmark to track, default is 8 for index finger tip.
-        self.finger_index = get_nested_key(data['config'], ['preprocessor', 'finger_index'], 8)
+        self.finger_index = get_nested_key("config.preprocessor.finger_index", data, 8)
         # buffer_size is the maximum number of points to store in the trajectory buffer.
-        self.buffer_size = get_nested_key(data['config'], ['preprocessor', 'buffer_size'], 30)
+        self.buffer_size = get_nested_key("config.preprocessor.buffer_size", data, 30)
         # min_steps is the minimum number of points needed for a valid trajectory.
-        self.min_steps = get_nested_key(data['config'], ['preprocessor', 'min_steps'], 10)
+        self.min_steps = get_nested_key("config.preprocessor.min_steps", data, 10)
         # max_lost is the maximum number of consecutive lost frames before ending the gesture.
-        self.max_lost = get_nested_key(data['config'], ['preprocessor', 'max_lost'], 5)
+        self.max_lost = get_nested_key("config.preprocessor.max_lost", data, 5)
         # min_speed_corner and reset_speed_corner are for hysteresis-based motion detection.
         # min_speed_corner is the threshold to start collecting when movement begins.
-        self.min_speed_corner = get_nested_key(data['config'], ['preprocessor', 'min_speed_corner'], 0.01)
+        self.min_speed_corner = get_nested_key("config.preprocessor.min_speed_corner", data, 0.01)
         # reset_speed_corner is the threshold to stop collecting when movement slows down.
-        self.reset_speed_corner = get_nested_key(data['config'], ['preprocessor', 'reset_speed_corner'], 0.005)
+        self.reset_speed_corner = get_nested_key("config.preprocessor.reset_speed_corner", data, 0.005)
         
         # Now, I create a deque to store the finger positions. It has a maximum length to keep only recent points.
         self.buffer = deque(maxlen=self.buffer_size)

--- a/GestureRecognition/modules/trailmarker.py
+++ b/GestureRecognition/modules/trailmarker.py
@@ -101,11 +101,11 @@ class TrailMarker(Module):
             Ein leeres Dictionary.
         """
         # Read configuration values using get_nested_key
-        self.finger_idx = get_nested_key(data['config'], ['trailmarker', 'finger_idx'])
-        self.max_lost = get_nested_key(data['config'], ['trailmarker', 'max_lost'])
-        self.max_trail_length = get_nested_key(data['config'], ['trailmarker', 'max_trail_length'])
-        self.webcam_width = get_nested_key(data['config'], ['webcam', 'width'])
-        self.webcam_height = get_nested_key(data['config'], ['webcam', 'height'])
+        self.finger_idx = get_nested_key("config.trailmarker.finger_idx", data)
+        self.max_lost = get_nested_key("config.trailmarker.max_lost", data)
+        self.max_trail_length = get_nested_key("config.trailmarker.max_trail_length", data)
+        self.webcam_width = get_nested_key("config.webcam.width", data)
+        self.webcam_height = get_nested_key("config.webcam.height", data)
         
         # Use collections.deque for trail history with fixed maximum length
         # Choice of data structure: deque is efficient for FIFO operations with max length,

--- a/README.md
+++ b/README.md
@@ -144,3 +144,48 @@ data/
 - Jede Aufnahme wird einzeln als `recording_{i}.pkl` gespeichert.
 - Die Nummer `{i}` zaehlt fortlaufend hoch. Bestehende Aufnahmen werden nie
   ueberschrieben.
+
+## Trainingsdatensatz bauen
+
+Mit `dataset_building(output_path)` in `GestureRecognition/labeling.py` wird
+aus den Rohaufnahmen unter `recordings/<label>/*.pkl` ein fertiger
+Trainingsdatensatz für den `HMMClassifier` erzeugt.
+
+### Aufruf
+
+```python
+from GestureRecognition.labeling import dataset_building
+
+result = dataset_building("data/dataset.pkl")
+```
+
+Das Ergebnis ist sowohl als Rückgabewert als auch als Pickle-Datei unter
+`output_path` verfügbar — ein Dict mit:
+
+- `X_train`, `X_test`: konkatenierte Feature-Arrays (x, y, velocity)
+- `y_train`, `y_test`: Klassenlabel pro Sequenz
+- `lengths_train`, `lengths_test`: Länge jeder einzelnen Sequenz
+- `classes`: sortierte Liste aller Klassenlabels
+
+Direkt nutzbar für:
+
+```python
+classifier.fit(result["X_train"], result["y_train"], result["lengths_train"])
+```
+
+### Sequenz-Level-Split (Data Leakage vermeiden)
+
+Jede Aufnahme ist eine ganze Geste, also eine Sequenz von Frames. Würde man
+einzelne **Frames** zufällig auf Train/Test verteilen, könnten Frames
+derselben Geste in beiden Sets landen. Das Modell hätte dann beim Testen
+quasi schon Teile der Antwort gesehen — die Testgenauigkeit wäre künstlich
+zu hoch. Deshalb wird auf Ebene ganzer **Aufnahmen** gesplittet: Jede
+Sequenz landet komplett in genau einem der beiden Sets.
+
+### Stratifizierung
+
+`stratify=labels` (über `train_test_split`) sorgt dafür, dass Train- und
+Test-Set für jede Klasse den gleichen Anteil an Aufnahmen enthalten. Bei
+z. B. 10 Aufnahmen pro Klasse und `test_size=0.2` landen pro Klasse 2 im
+Test-Set. Ohne Stratifizierung könnte eine Klasse bei wenigen Aufnahmen rein
+zufällig komplett im Train- oder Test-Set landen.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,44 @@ data/
 - Die Nummer `{i}` zaehlt fortlaufend hoch. Bestehende Aufnahmen werden nie
   ueberschrieben.
 
+## Alphabet-Sammlung im Team (A–Z, 1× pro Person)
+
+Damit das Team schnell und reibungslos Trainingsdaten sammeln kann, gibt es ein
+geführtes Skript, das eine Person automatisch durch **alle 26 Buchstaben** führt
+und je **eine** Aufnahme pro Buchstabe macht. Die Aufnahmen landen direkt in
+`recordings/<Buchstabe>/` — also genau dort, wo `dataset_building()` liest.
+
+### Aufruf
+
+```bash
+python collect_alphabet.py --person arian
+# oder ohne Argument, dann wird der Name abgefragt:
+python collect_alphabet.py
+```
+
+- Pro Buchstabe: ENTER → Geste ausführen → Fenster schließen → `s`/`v`/`a`
+  (speichern / verwerfen / abbrechen) wie beim normalen Labeling.
+- **Resume:** Buchstaben, die diese Person schon aufgenommen hat, werden
+  übersprungen. Der Durchlauf kann jederzeit abgebrochen und später fortgesetzt
+  werden — nichts wird überschrieben.
+
+### Dateibenennung
+
+Jede Aufnahme heißt `recordings/<Buchstabe>/<Buchstabe>-<person>.pkl`
+(z. B. `recordings/A/A-arian.pkl`). So ist nachvollziehbar, dass jedes
+Teammitglied jeden Buchstaben genau einmal aufgenommen hat, und Doppelungen
+derselben Person werden verhindert.
+
+### Danach: Datensatz bauen
+
+Sind alle vier Personen durch, einmalig den Trainingsdatensatz erzeugen:
+
+```bash
+python -c "from GestureRecognition.labeling import dataset_building; dataset_building('data/dataset.pkl')"
+```
+
+Details dazu im nächsten Abschnitt.
+
 ## Trainingsdatensatz bauen
 
 Mit `dataset_building(output_path)` in `GestureRecognition/labeling.py` wird

--- a/collect_alphabet.py
+++ b/collect_alphabet.py
@@ -5,16 +5,22 @@ from GestureRecognition.labeling import collect_alphabet
 
 def main():
     parser = argparse.ArgumentParser(
-        "Alphabet-Aufnahme (A-Z, je 1x pro Person)"
+        "Alphabet-Aufnahme (A-Z, je mehrfach pro Person)"
     )
     parser.add_argument(
         "--person",
         help="Dein Name / Kuerzel (wird sonst interaktiv abgefragt)",
     )
+    parser.add_argument(
+        "--times",
+        type=int,
+        default=15,
+        help="Wie viele Takes pro Buchstabe (Standard: 15)",
+    )
     args = parser.parse_args()
 
     person = args.person or input("Dein Name / Kuerzel: ").strip()
-    collect_alphabet(person)
+    collect_alphabet(person, times=args.times)
 
 
 if __name__ == "__main__":

--- a/collect_alphabet.py
+++ b/collect_alphabet.py
@@ -1,0 +1,21 @@
+import argparse
+
+from GestureRecognition.labeling import collect_alphabet
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        "Alphabet-Aufnahme (A-Z, je 1x pro Person)"
+    )
+    parser.add_argument(
+        "--person",
+        help="Dein Name / Kuerzel (wird sonst interaktiv abgefragt)",
+    )
+    args = parser.parse_args()
+
+    person = args.person or input("Dein Name / Kuerzel: ").strip()
+    collect_alphabet(person)
+
+
+if __name__ == "__main__":
+    main()

--- a/config.yml
+++ b/config.yml
@@ -3,13 +3,18 @@ engine:
   autoclose: False
 recorder:
   file: record/test.pickle
+  record:
+    - trailmarker
+    - preprocessor
+    - hiddenmarkov
+    - detector
   replay:
     - trailmarker
     - preprocessor
     - hiddenmarkov
     - detector
 webcam:
-  deviceIndex: 2
+  deviceIndex: 0
   width: 640
   height: 360
   dtype: u8

--- a/docs/alphabet-collection.md
+++ b/docs/alphabet-collection.md
@@ -1,0 +1,103 @@
+# Alphabet-Datenerfassung im Team (A–Z)
+
+Dieses Dokument beschreibt die vereinfachte Gesten-Datenerfassung für die 26
+Buchstaben des Alphabets: **was** geändert wurde und **wie** ihr es benutzt.
+
+## Ziel
+
+Jedes der vier Teammitglieder nimmt jeden Buchstaben **genau einmal** auf, um
+gute Diversität in den Trainingsdaten zu erzeugen. Die Aufnahmen landen direkt
+dort, wo das Training liest, sodass danach ohne Umwege ein Datensatz gebaut und
+das Modell trainiert werden kann.
+
+## Was wurde gebaut
+
+| Datei | Änderung |
+|-------|----------|
+| `collect_alphabet.py` (neu, Repo-Wurzel) | Einstiegsskript für den geführten Aufnahme-Durchlauf. |
+| `GestureRecognition/labeling.py` | Neue Funktion `collect_alphabet(person, recordings_dir="recordings")`. Aufnahme-Logik einer Einzelaufnahme in `_record_one_take()` extrahiert (von `data_labeling` mitbenutzt). |
+| `README.md` | Abschnitt „Alphabet-Sammlung im Team". |
+
+Wichtig: `data_labeling`, `dataset_building`, `clean_recordings` und die
+Pipeline bleiben **funktional unverändert** – `data_labeling` nutzt nur denselben
+neuen Helfer (gleiches Verhalten wie zuvor).
+
+## Wie benutzen
+
+### 1. Voraussetzungen (einmalig)
+
+Setup wie in der README: venv aktiviert, `requirements.txt` installiert,
+`hand_landmarker.task` heruntergeladen, `recordings.zip` entpackt, Webcam-Index
+in `config.yml` gesetzt.
+
+### 2. Aufnahme-Durchlauf starten
+
+```bash
+source .venv/bin/activate
+
+# macOS: Qt-Pfad setzen, sonst crasht das Fenster
+export QT_QPA_PLATFORM_PLUGIN_PATH=$(python -c "import PyQt5, os; print(os.path.join(os.path.dirname(PyQt5.__file__), 'Qt5', 'plugins', 'platforms'))")
+
+python collect_alphabet.py --person <deinName>
+# ohne --person wird der Name interaktiv abgefragt
+```
+
+Pro Buchstabe:
+
+1. Großanzeige des Buchstabens + Fortschritt (`A  [1/26]`) → **ENTER** drücken.
+2. Kamerafenster öffnet sich → Geste ausführen → **Fenster schließen**.
+3. Entscheiden: `s` speichern · `v` verwerfen (Buchstabe wiederholen) ·
+   `a` abbrechen (ganzen Durchlauf beenden).
+
+### 3. Resume (jederzeit fortsetzbar)
+
+Bereits aufgenommene Buchstaben dieser Person werden beim nächsten Start
+**übersprungen**. Ihr könnt also abbrechen und später weitermachen, ohne etwas
+zu überschreiben.
+
+### 4. Speicherort & Benennung
+
+```
+recordings/
+├── A/
+│   ├── A-arian.pkl
+│   ├── A-wayan.pkl
+│   └── ...
+├── B/
+│   └── ...
+└── Z/
+```
+
+Format: `recordings/<Buchstabe>/<Buchstabe>-<person>.pkl`. So ist
+nachvollziehbar, dass jede Person jeden Buchstaben einmal hat, und
+Doppelaufnahmen derselben Person werden verhindert.
+
+Der Personenname darf keine Leerzeichen, Slashes oder Doppelpunkte enthalten
+(er wird Teil des Dateinamens) – sonst gibt es eine klare Fehlermeldung.
+
+## Danach: Datensatz bauen & trainieren
+
+Sind alle vier Personen durch:
+
+```bash
+python -c "from GestureRecognition.labeling import dataset_building; dataset_building('data/dataset.pkl')"
+```
+
+`dataset_building` liest standardmäßig aus `recordings/`, findet also alle neuen
+Aufnahmen automatisch. Optional zur Qualitätskontrolle:
+
+```bash
+python -c "from GestureRecognition.visualization import visualize_dataset; visualize_dataset()"
+```
+
+Training mit dem erzeugten Datensatz:
+
+```python
+import pickle
+from GestureRecognition.hmmclassifier import HMMClassifier
+
+d = pickle.load(open("data/dataset.pkl", "rb"))
+clf = HMMClassifier()
+clf.fit(d["X_train"], d["y_train"], d["lengths_train"])
+clf.save("data/hmm.pkl")
+```

--- a/docs/alphabet-collection.md
+++ b/docs/alphabet-collection.md
@@ -101,3 +101,47 @@ clf = HMMClassifier()
 clf.fit(d["X_train"], d["y_train"], d["lengths_train"])
 clf.save("data/hmm.pkl")
 ```
+
+## Fehlerbehebung (wichtig — nicht bei allen gleich!)
+
+Beim ersten Einrichten können je nach Rechner/Kamera ein paar Dinge
+abweichen. Diese Punkte mussten beim ersten Testlauf angepasst werden:
+
+- **Kamera-Index (`config.yml` → `webcam.deviceIndex`):** Nicht bei jedem ist
+  die Kamera am selben Port. Falls das Fenster schwarz bleibt oder ein
+  Kamerafehler kommt, den richtigen Index ermitteln:
+
+  ```bash
+  python -c "
+  import cv2
+  for i in range(5):
+      cap = cv2.VideoCapture(i)
+      print(f'Index {i}:', 'OK' if (cap.isOpened() and cap.read()[0]) else '-')
+      cap.release()
+  "
+  ```
+
+  Den ersten Index mit `OK` in `config.yml` als `deviceIndex` eintragen
+  (eingebaute MacBook-Kamera ist meist `0`). Beim allerersten Lauf fragt macOS
+  einmalig nach der **Kamera-Erlaubnis** — erlauben und erneut starten.
+
+- **mediapipe-Version:** `requirements.txt` pinnt `mediapipe==0.10.32`. Diese
+  Version gibt es nicht für jede Plattform (z. B. Intel-macOS). Falls die
+  Installation scheitert, eine verfügbare Version nehmen:
+  `pip install "mediapipe>=0.10.20,<0.11"`.
+
+- **Schwarzes Fenster trotz Kamera:** War ein Bug — `Webcam()` war in
+  [demo.py](../GestureRecognition/demo.py) auskommentiert. Ist in diesem Branch
+  behoben (Webcam wird für Record-/Live-Modus automatisch aktiviert).
+
+- **`config.recorder.record` fehlte / `record_list is None`:** War ein Bug —
+  in [config.yml](../config.yml) gab es nur `recorder.replay`, nicht
+  `recorder.record`. Ist in diesem Branch behoben.
+
+- **`'dict' object has no attribute 'split'`:** War ein Bug — `TrailMarker` und
+  `Preprocessor` nutzten eine veraltete `get_nested_key`-Signatur. Ist in
+  diesem Branch behoben (jetzt einheitlich `get_nested_key("config.x.y", data)`
+  wie im `HandDetector`).
+
+- **macOS Qt-Crash:** Vor dem Start immer den `QT_QPA_PLATFORM_PLUGIN_PATH`
+  setzen (siehe oben), sonst stürzt das Fenster ab.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "matplotlib>=3.7",
     "mediapipe>=0.10.32",
     "numpy>=1.26,<2.1",
+    "scikit-learn>=1.3",
     "signalhub",
     "tqdm>=4.67.3",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ hmmlearn==0.3.3
 matplotlib>=3.7
 mediapipe==0.10.32
 numpy>=1.26,<2.1
+scikit-learn>=1.3
 signalhub @ git+https://github.com/jaboll-ai/SignalHub.git@pyproject
 tqdm==4.67.3

--- a/uv.lock
+++ b/uv.lock
@@ -316,7 +316,11 @@ name = "gesturerecognition"
 version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
+    { name = "hmmlearn" },
+    { name = "matplotlib" },
     { name = "mediapipe" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
     { name = "signalhub" },
     { name = "tqdm" },
 ]
@@ -329,7 +333,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "hmmlearn", specifier = ">=0.3.3" },
+    { name = "matplotlib", specifier = ">=3.7" },
     { name = "mediapipe", specifier = ">=0.10.32" },
+    { name = "numpy", specifier = ">=1.26,<2.1" },
+    { name = "scikit-learn", specifier = ">=1.3" },
     { name = "signalhub", git = "https://github.com/jaboll-ai/SignalHub.git?rev=pyproject" },
     { name = "tqdm", specifier = ">=4.67.3" },
 ]
@@ -338,6 +346,29 @@ requires-dist = [
 dev = [
     { name = "sphinx", specifier = ">=9.1.0" },
     { name = "sphinx-rtd-theme", specifier = ">=3.1.0" },
+]
+
+[[package]]
+name = "hmmlearn"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/77/89cdfbfaa2beb51f8cc57f83f9b4f653ec3faa660ba2e2146cc84bfc8eb9/hmmlearn-0.3.3.tar.gz", hash = "sha256:1d3c5dc4c5257e0c238dc1fe5387700b8cb987eab808edb3e0c73829f1cc44ec", size = 78535, upload-time = "2024-10-31T09:04:20.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/fb/c5e6522a6f596b24c0190cb7579e4d5beb993e4547e34d754bf33e9efc0a/hmmlearn-0.3.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:898e2fd51244db793659b4eac584871addaf6e57efe72121e753d57b3fb1128f", size = 196051, upload-time = "2024-10-31T09:03:38.19Z" },
+    { url = "https://files.pythonhosted.org/packages/05/42/2ce8e5d10425fb56820be575894ee6d8a4b33eb92889588e6a3406299e82/hmmlearn-0.3.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:86ad9fa4319588212c0bc7f7f9a050b01138f76b7f69d83f50d687fe4f9dcd28", size = 130844, upload-time = "2024-10-31T09:03:39.263Z" },
+    { url = "https://files.pythonhosted.org/packages/03/fc/54dd991c71f32ddcf846cb99e21118166fb4341a0a9094f1e79add20d4b2/hmmlearn-0.3.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1128973a42fcf631579ef1b305e57e342aaf8769839a9899bff614ccc9d82c21", size = 163510, upload-time = "2024-10-31T09:03:41.617Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c8/88973fc908111491747cf1737d1c30f5d1a5f777ea3cdf625c8fcb3cdd9d/hmmlearn-0.3.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6cd27dc66bfe7f6ff77804f7dbfe42b35d18e21403eb2bdfef0de6ad3bd2368f", size = 165953, upload-time = "2024-10-31T09:03:44.513Z" },
+    { url = "https://files.pythonhosted.org/packages/92/57/24bd2359bf0f2a2514f7b53f0bca562f912ac4751e415756b9138970c5aa/hmmlearn-0.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:49ed0d2451d9884d0bdfbe84dd14b3a699382b00bed931d6a5ca46997978a1c4", size = 127297, upload-time = "2024-10-31T09:03:47.744Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/34/ad66eead2db6f03aebdc2feaa6992d803adf581628c6d67ad093fb3922e4/hmmlearn-0.3.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:4a6da5aa01bb9beeef311706b03c16d411f93ef68220ad442f2eca8ef39da0a6", size = 196173, upload-time = "2024-10-31T09:03:49.539Z" },
+    { url = "https://files.pythonhosted.org/packages/17/15/53ee1f4c8905d3a74acc2314c626c1cf1f4a7b11384390dd9d8ed66e9c1b/hmmlearn-0.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:41d8e2ae07ac5e9e48e693a4918e3a3717edd32328bd4b9d878c323c5358e625", size = 130886, upload-time = "2024-10-31T09:03:51.66Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/09/eb7abbc42b13a3a1983d825cfea170cf7a6033df9ea4fdc94aa2c94539b8/hmmlearn-0.3.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:11de9f8bc0bea1a70cdfeca9466682c2131b00da53d0898f3b1d79aadffa85a9", size = 163428, upload-time = "2024-10-31T09:03:53.722Z" },
+    { url = "https://files.pythonhosted.org/packages/88/99/a0397750ee53ef7e6c18b82eec4bee41450216a59bd73153855eda8c2d22/hmmlearn-0.3.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:491f3bd9e3c01fa1201057e1de2c87039fed0e225ad562111ad4a0e25c40ef00", size = 165968, upload-time = "2024-10-31T09:03:56.102Z" },
+    { url = "https://files.pythonhosted.org/packages/59/3b/2e49e18e927203384bb0792c1d935dd371c1d14ed8d9cfacd9d0daccc35c/hmmlearn-0.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:8f39d658a6366cb839157bdd8a075c62a43d3175e0f453145b5f2cdcdc05b4e3", size = 127334, upload-time = "2024-10-31T09:03:58.453Z" },
 ]
 
 [[package]]
@@ -368,6 +399,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]
@@ -619,64 +659,30 @@ wheels = [
 ]
 
 [[package]]
-name = "numpy"
-version = "2.4.3"
+name = "narwhals"
+version = "2.22.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/10/8b/c265f4823726ab832de836cdd184d0986dcf94480f81e8739692a7ac7af2/numpy-2.4.3.tar.gz", hash = "sha256:483a201202b73495f00dbc83796c6ae63137a9bdade074f7648b3e32613412dd", size = 20727743, upload-time = "2026-03-09T07:58:53.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493, upload-time = "2026-06-05T12:34:34.051Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/ed/6388632536f9788cea23a3a1b629f25b43eaacd7d7377e5d6bc7b9deb69b/numpy-2.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:61b0cbabbb6126c8df63b9a3a0c4b1f44ebca5e12ff6997b80fcf267fb3150ef", size = 16669628, upload-time = "2026-03-09T07:56:24.252Z" },
-    { url = "https://files.pythonhosted.org/packages/74/1b/ee2abfc68e1ce728b2958b6ba831d65c62e1b13ce3017c13943f8f9b5b2e/numpy-2.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7395e69ff32526710748f92cd8c9849b361830968ea3e24a676f272653e8983e", size = 14696872, upload-time = "2026-03-09T07:56:26.991Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/d1/780400e915ff5638166f11ca9dc2c5815189f3d7cf6f8759a1685e586413/numpy-2.4.3-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:abdce0f71dcb4a00e4e77f3faf05e4616ceccfe72ccaa07f47ee79cda3b7b0f4", size = 5203489, upload-time = "2026-03-09T07:56:29.414Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/bb/baffa907e9da4cc34a6e556d6d90e032f6d7a75ea47968ea92b4858826c4/numpy-2.4.3-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:48da3a4ee1336454b07497ff7ec83903efa5505792c4e6d9bf83d99dc07a1e18", size = 6550814, upload-time = "2026-03-09T07:56:32.225Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/12/8c9f0c6c95f76aeb20fc4a699c33e9f827fa0d0f857747c73bb7b17af945/numpy-2.4.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32e3bef222ad6b052280311d1d60db8e259e4947052c3ae7dd6817451fc8a4c5", size = 15666601, upload-time = "2026-03-09T07:56:34.461Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/79/cc665495e4d57d0aa6fbcc0aa57aa82671dfc78fbf95fe733ed86d98f52a/numpy-2.4.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7dd01a46700b1967487141a66ac1a3cf0dd8ebf1f08db37d46389401512ca97", size = 16621358, upload-time = "2026-03-09T07:56:36.852Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/40/b4ecb7224af1065c3539f5ecfff879d090de09608ad1008f02c05c770cb3/numpy-2.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:76f0f283506c28b12bba319c0fab98217e9f9b54e6160e9c79e9f7348ba32e9c", size = 17016135, upload-time = "2026-03-09T07:56:39.337Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/b1/6a88e888052eed951afed7a142dcdf3b149a030ca59b4c71eef085858e43/numpy-2.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:737f630a337364665aba3b5a77e56a68cc42d350edd010c345d65a3efa3addcc", size = 18345816, upload-time = "2026-03-09T07:56:42.31Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/8f/103a60c5f8c3d7fc678c19cd7b2476110da689ccb80bc18050efbaeae183/numpy-2.4.3-cp312-cp312-win32.whl", hash = "sha256:26952e18d82a1dbbc2f008d402021baa8d6fc8e84347a2072a25e08b46d698b9", size = 5960132, upload-time = "2026-03-09T07:56:44.851Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/7c/f5ee1bf6ed888494978046a809df2882aad35d414b622893322df7286879/numpy-2.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:65f3c2455188f09678355f5cae1f959a06b778bc66d535da07bf2ef20cd319d5", size = 12316144, upload-time = "2026-03-09T07:56:47.057Z" },
-    { url = "https://files.pythonhosted.org/packages/71/46/8d1cb3f7a00f2fb6394140e7e6623696e54c6318a9d9691bb4904672cf42/numpy-2.4.3-cp312-cp312-win_arm64.whl", hash = "sha256:2abad5c7fef172b3377502bde47892439bae394a71bc329f31df0fd829b41a9e", size = 10220364, upload-time = "2026-03-09T07:56:49.849Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/d0/1fe47a98ce0df229238b77611340aff92d52691bcbc10583303181abf7fc/numpy-2.4.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b346845443716c8e542d54112966383b448f4a3ba5c66409771b8c0889485dd3", size = 16665297, upload-time = "2026-03-09T07:56:52.296Z" },
-    { url = "https://files.pythonhosted.org/packages/27/d9/4e7c3f0e68dfa91f21c6fb6cf839bc829ec920688b1ce7ec722b1a6202fb/numpy-2.4.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2629289168f4897a3c4e23dc98d6f1731f0fc0fe52fb9db19f974041e4cc12b9", size = 14691853, upload-time = "2026-03-09T07:56:54.992Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/66/bd096b13a87549683812b53ab211e6d413497f84e794fb3c39191948da97/numpy-2.4.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:bb2e3cf95854233799013779216c57e153c1ee67a0bf92138acca0e429aefaee", size = 5198435, upload-time = "2026-03-09T07:56:57.184Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/2f/687722910b5a5601de2135c891108f51dfc873d8e43c8ed9f4ebb440b4a2/numpy-2.4.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:7f3408ff897f8ab07a07fbe2823d7aee6ff644c097cc1f90382511fe982f647f", size = 6546347, upload-time = "2026-03-09T07:56:59.531Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/ec/7971c4e98d86c564750393fab8d7d83d0a9432a9d78bb8a163a6dc59967a/numpy-2.4.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:decb0eb8a53c3b009b0962378065589685d66b23467ef5dac16cbe818afde27f", size = 15664626, upload-time = "2026-03-09T07:57:01.385Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/eb/7daecbea84ec935b7fc732e18f532073064a3816f0932a40a17f3349185f/numpy-2.4.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5f51900414fc9204a0e0da158ba2ac52b75656e7dce7e77fb9f84bfa343b4cc", size = 16608916, upload-time = "2026-03-09T07:57:04.008Z" },
-    { url = "https://files.pythonhosted.org/packages/df/58/2a2b4a817ffd7472dca4421d9f0776898b364154e30c95f42195041dc03b/numpy-2.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6bd06731541f89cdc01b261ba2c9e037f1543df7472517836b78dfb15bd6e476", size = 17015824, upload-time = "2026-03-09T07:57:06.347Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/ca/627a828d44e78a418c55f82dd4caea8ea4a8ef24e5144d9e71016e52fb40/numpy-2.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22654fe6be0e5206f553a9250762c653d3698e46686eee53b399ab90da59bd92", size = 18334581, upload-time = "2026-03-09T07:57:09.114Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/c0/76f93962fc79955fcba30a429b62304332345f22d4daec1cb33653425643/numpy-2.4.3-cp313-cp313-win32.whl", hash = "sha256:d71e379452a2f670ccb689ec801b1218cd3983e253105d6e83780967e899d687", size = 5958618, upload-time = "2026-03-09T07:57:11.432Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/3c/88af0040119209b9b5cb59485fa48b76f372c73068dbf9254784b975ac53/numpy-2.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:0a60e17a14d640f49146cb38e3f105f571318db7826d9b6fef7e4dce758faecd", size = 12312824, upload-time = "2026-03-09T07:57:13.586Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ce/3d07743aced3d173f877c3ef6a454c2174ba42b584ab0b7e6d99374f51ed/numpy-2.4.3-cp313-cp313-win_arm64.whl", hash = "sha256:c9619741e9da2059cd9c3f206110b97583c7152c1dc9f8aafd4beb450ac1c89d", size = 10221218, upload-time = "2026-03-09T07:57:16.183Z" },
-    { url = "https://files.pythonhosted.org/packages/62/09/d96b02a91d09e9d97862f4fc8bfebf5400f567d8eb1fe4b0cc4795679c15/numpy-2.4.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7aa4e54f6469300ebca1d9eb80acd5253cdfa36f2c03d79a35883687da430875", size = 14819570, upload-time = "2026-03-09T07:57:18.564Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/ca/0b1aba3905fdfa3373d523b2b15b19029f4f3031c87f4066bd9d20ef6c6b/numpy-2.4.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d1b90d840b25874cf5cd20c219af10bac3667db3876d9a495609273ebe679070", size = 5326113, upload-time = "2026-03-09T07:57:21.052Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/63/406e0fd32fcaeb94180fd6a4c41e55736d676c54346b7efbce548b94a914/numpy-2.4.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:a749547700de0a20a6718293396ec237bb38218049cfce788e08fcb716e8cf73", size = 6646370, upload-time = "2026-03-09T07:57:22.804Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/d0/10f7dc157d4b37af92720a196be6f54f889e90dcd30dce9dc657ed92c257/numpy-2.4.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f3c4a151a2e529adf49c1d54f0f57ff8f9b233ee4d44af623a81553ab86368", size = 15723499, upload-time = "2026-03-09T07:57:24.693Z" },
-    { url = "https://files.pythonhosted.org/packages/66/f1/d1c2bf1161396629701bc284d958dc1efa3a5a542aab83cf11ee6eb4cba5/numpy-2.4.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22c31dc07025123aedf7f2db9e91783df13f1776dc52c6b22c620870dc0fab22", size = 16657164, upload-time = "2026-03-09T07:57:27.676Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/be/cca19230b740af199ac47331a21c71e7a3d0ba59661350483c1600d28c37/numpy-2.4.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:148d59127ac95979d6f07e4d460f934ebdd6eed641db9c0db6c73026f2b2101a", size = 17081544, upload-time = "2026-03-09T07:57:30.664Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c5/9602b0cbb703a0936fb40f8a95407e8171935b15846de2f0776e08af04c7/numpy-2.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a97cbf7e905c435865c2d939af3d93f99d18eaaa3cabe4256f4304fb51604349", size = 18380290, upload-time = "2026-03-09T07:57:33.763Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/81/9f24708953cd30be9ee36ec4778f4b112b45165812f2ada4cc5ea1c1f254/numpy-2.4.3-cp313-cp313t-win32.whl", hash = "sha256:be3b8487d725a77acccc9924f65fd8bce9af7fac8c9820df1049424a2115af6c", size = 6082814, upload-time = "2026-03-09T07:57:36.491Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/9e/52f6eaa13e1a799f0ab79066c17f7016a4a8ae0c1aefa58c82b4dab690b4/numpy-2.4.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1ec84fd7c8e652b0f4aaaf2e6e9cc8eaa9b1b80a537e06b2e3a2fb176eedcb26", size = 12452673, upload-time = "2026-03-09T07:57:38.281Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/04/b8cece6ead0b30c9fbd99bb835ad7ea0112ac5f39f069788c5558e3b1ab2/numpy-2.4.3-cp313-cp313t-win_arm64.whl", hash = "sha256:120df8c0a81ebbf5b9020c91439fccd85f5e018a927a39f624845be194a2be02", size = 10290907, upload-time = "2026-03-09T07:57:40.747Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ae/3936f79adebf8caf81bd7a599b90a561334a658be4dcc7b6329ebf4ee8de/numpy-2.4.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5884ce5c7acfae1e4e1b6fde43797d10aa506074d25b531b4f54bde33c0c31d4", size = 16664563, upload-time = "2026-03-09T07:57:43.817Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/62/760f2b55866b496bb1fa7da2a6db076bef908110e568b02fcfc1422e2a3a/numpy-2.4.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:297837823f5bc572c5f9379b0c9f3a3365f08492cbdc33bcc3af174372ebb168", size = 14702161, upload-time = "2026-03-09T07:57:46.169Z" },
-    { url = "https://files.pythonhosted.org/packages/32/af/a7a39464e2c0a21526fb4fb76e346fb172ebc92f6d1c7a07c2c139cc17b1/numpy-2.4.3-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a111698b4a3f8dcbe54c64a7708f049355abd603e619013c346553c1fd4ca90b", size = 5208738, upload-time = "2026-03-09T07:57:48.506Z" },
-    { url = "https://files.pythonhosted.org/packages/29/8c/2a0cf86a59558fa078d83805589c2de490f29ed4fb336c14313a161d358a/numpy-2.4.3-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:4bd4741a6a676770e0e97fe9ab2e51de01183df3dcbcec591d26d331a40de950", size = 6543618, upload-time = "2026-03-09T07:57:50.591Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/b8/612ce010c0728b1c363fa4ea3aa4c22fe1c5da1de008486f8c2f5cb92fae/numpy-2.4.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54f29b877279d51e210e0c80709ee14ccbbad647810e8f3d375561c45ef613dd", size = 15680676, upload-time = "2026-03-09T07:57:52.34Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/7e/4f120ecc54ba26ddf3dc348eeb9eb063f421de65c05fc961941798feea18/numpy-2.4.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:679f2a834bae9020f81534671c56fd0cc76dd7e5182f57131478e23d0dc59e24", size = 16613492, upload-time = "2026-03-09T07:57:54.91Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/86/1b6020db73be330c4b45d5c6ee4295d59cfeef0e3ea323959d053e5a6909/numpy-2.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d84f0f881cb2225c2dfd7f78a10a5645d487a496c6668d6cc39f0f114164f3d0", size = 17031789, upload-time = "2026-03-09T07:57:57.641Z" },
-    { url = "https://files.pythonhosted.org/packages/07/3a/3b90463bf41ebc21d1b7e06079f03070334374208c0f9a1f05e4ae8455e7/numpy-2.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d213c7e6e8d211888cc359bab7199670a00f5b82c0978b9d1c75baf1eddbeac0", size = 18339941, upload-time = "2026-03-09T07:58:00.577Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/74/6d736c4cd962259fd8bae9be27363eb4883a2f9069763747347544c2a487/numpy-2.4.3-cp314-cp314-win32.whl", hash = "sha256:52077feedeff7c76ed7c9f1a0428558e50825347b7545bbb8523da2cd55c547a", size = 6007503, upload-time = "2026-03-09T07:58:03.331Z" },
-    { url = "https://files.pythonhosted.org/packages/48/39/c56ef87af669364356bb011922ef0734fc49dad51964568634c72a009488/numpy-2.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:0448e7f9caefb34b4b7dd2b77f21e8906e5d6f0365ad525f9f4f530b13df2afc", size = 12444915, upload-time = "2026-03-09T07:58:06.353Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/1f/ab8528e38d295fd349310807496fabb7cf9fe2e1f70b97bc20a483ea9d4a/numpy-2.4.3-cp314-cp314-win_arm64.whl", hash = "sha256:b44fd60341c4d9783039598efadd03617fa28d041fc37d22b62d08f2027fa0e7", size = 10494875, upload-time = "2026-03-09T07:58:08.734Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/ef/b7c35e4d5ef141b836658ab21a66d1a573e15b335b1d111d31f26c8ef80f/numpy-2.4.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0a195f4216be9305a73c0e91c9b026a35f2161237cf1c6de9b681637772ea657", size = 14822225, upload-time = "2026-03-09T07:58:11.034Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/8d/7730fa9278cf6648639946cc816e7cc89f0d891602584697923375f801ed/numpy-2.4.3-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:cd32fbacb9fd1bf041bf8e89e4576b6f00b895f06d00914820ae06a616bdfef7", size = 5328769, upload-time = "2026-03-09T07:58:13.67Z" },
-    { url = "https://files.pythonhosted.org/packages/47/01/d2a137317c958b074d338807c1b6a383406cdf8b8e53b075d804cc3d211d/numpy-2.4.3-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:2e03c05abaee1f672e9d67bc858f300b5ccba1c21397211e8d77d98350972093", size = 6649461, upload-time = "2026-03-09T07:58:15.912Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/34/812ce12bc0f00272a4b0ec0d713cd237cb390666eb6206323d1cc9cedbb2/numpy-2.4.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d1ce23cce91fcea443320a9d0ece9b9305d4368875bab09538f7a5b4131938a", size = 15725809, upload-time = "2026-03-09T07:58:17.787Z" },
-    { url = "https://files.pythonhosted.org/packages/25/c0/2aed473a4823e905e765fee3dc2cbf504bd3e68ccb1150fbdabd5c39f527/numpy-2.4.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c59020932feb24ed49ffd03704fbab89f22aa9c0d4b180ff45542fe8918f5611", size = 16655242, upload-time = "2026-03-09T07:58:20.476Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/c8/7e052b2fc87aa0e86de23f20e2c42bd261c624748aa8efd2c78f7bb8d8c6/numpy-2.4.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9684823a78a6cd6ad7511fc5e25b07947d1d5b5e2812c93fe99d7d4195130720", size = 17080660, upload-time = "2026-03-09T07:58:23.067Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/3d/0876746044db2adcb11549f214d104f2e1be00f07a67edbb4e2812094847/numpy-2.4.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0200b25c687033316fb39f0ff4e3e690e8957a2c3c8d22499891ec58c37a3eb5", size = 18380384, upload-time = "2026-03-09T07:58:25.839Z" },
-    { url = "https://files.pythonhosted.org/packages/07/12/8160bea39da3335737b10308df4f484235fd297f556745f13092aa039d3b/numpy-2.4.3-cp314-cp314t-win32.whl", hash = "sha256:5e10da9e93247e554bb1d22f8edc51847ddd7dde52d85ce31024c1b4312bfba0", size = 6154547, upload-time = "2026-03-09T07:58:28.289Z" },
-    { url = "https://files.pythonhosted.org/packages/42/f3/76534f61f80d74cc9cdf2e570d3d4eeb92c2280a27c39b0aaf471eda7b48/numpy-2.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:45f003dbdffb997a03da2d1d0cb41fbd24a87507fb41605c0420a3db5bd4667b", size = 12633645, upload-time = "2026-03-09T07:58:30.384Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/b6/7c0d4334c15983cec7f92a69e8ce9b1e6f31857e5ee3a413ac424e6bd63d/numpy-2.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:4d382735cecd7bcf090172489a525cd7d4087bc331f7df9f60ddc9a296cf208e", size = 10565454, upload-time = "2026-03-09T07:58:33.031Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815, upload-time = "2026-06-05T12:34:32.289Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/75/10dd1f8116a8b796cb2c737b674e02d02e80454bda953fa7e65d8c12b016/numpy-2.0.2.tar.gz", hash = "sha256:883c987dee1880e2a864ab0dc9892292582510604156762362d9326444636e78", size = 18902015, upload-time = "2024-08-26T20:19:40.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/40/2e117be60ec50d98fa08c2f8c48e09b3edea93cfcabd5a9ff6925d54b1c2/numpy-2.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:df55d490dea7934f330006d0f81e8551ba6010a5bf035a249ef61a94f21c500b", size = 20895803, upload-time = "2024-08-26T20:11:13.916Z" },
+    { url = "https://files.pythonhosted.org/packages/46/92/1b8b8dee833f53cef3e0a3f69b2374467789e0bb7399689582314df02651/numpy-2.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8df823f570d9adf0978347d1f926b2a867d5608f434a7cff7f7908c6570dcf5e", size = 13471835, upload-time = "2024-08-26T20:11:34.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/19/e2793bde475f1edaea6945be141aef6c8b4c669b90c90a300a8954d08f0a/numpy-2.0.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9a92ae5c14811e390f3767053ff54eaee3bf84576d99a2456391401323f4ec2c", size = 5038499, upload-time = "2024-08-26T20:11:43.902Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ff/ddf6dac2ff0dd50a7327bcdba45cb0264d0e96bb44d33324853f781a8f3c/numpy-2.0.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:a842d573724391493a97a62ebbb8e731f8a5dcc5d285dfc99141ca15a3302d0c", size = 6633497, upload-time = "2024-08-26T20:11:55.09Z" },
+    { url = "https://files.pythonhosted.org/packages/72/21/67f36eac8e2d2cd652a2e69595a54128297cdcb1ff3931cfc87838874bd4/numpy-2.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05e238064fc0610c840d1cf6a13bf63d7e391717d247f1bf0318172e759e692", size = 13621158, upload-time = "2024-08-26T20:12:14.95Z" },
+    { url = "https://files.pythonhosted.org/packages/39/68/e9f1126d757653496dbc096cb429014347a36b228f5a991dae2c6b6cfd40/numpy-2.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0123ffdaa88fa4ab64835dcbde75dcdf89c453c922f18dced6e27c90d1d0ec5a", size = 19236173, upload-time = "2024-08-26T20:12:44.049Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e9/1f5333281e4ebf483ba1c888b1d61ba7e78d7e910fdd8e6499667041cc35/numpy-2.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:96a55f64139912d61de9137f11bf39a55ec8faec288c75a54f93dfd39f7eb40c", size = 19634174, upload-time = "2024-08-26T20:13:13.634Z" },
+    { url = "https://files.pythonhosted.org/packages/71/af/a469674070c8d8408384e3012e064299f7a2de540738a8e414dcfd639996/numpy-2.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ec9852fb39354b5a45a80bdab5ac02dd02b15f44b3804e9f00c556bf24b4bded", size = 14099701, upload-time = "2024-08-26T20:13:34.851Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/3d/08ea9f239d0e0e939b6ca52ad403c84a2bce1bde301a8eb4888c1c1543f1/numpy-2.0.2-cp312-cp312-win32.whl", hash = "sha256:671bec6496f83202ed2d3c8fdc486a8fc86942f2e69ff0e986140339a63bcbe5", size = 6174313, upload-time = "2024-08-26T20:13:45.653Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/b5/4ac39baebf1fdb2e72585c8352c56d063b6126be9fc95bd2bb5ef5770c20/numpy-2.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:cfd41e13fdc257aa5778496b8caa5e856dc4896d4ccf01841daee1d96465467a", size = 15606179, upload-time = "2024-08-26T20:14:08.786Z" },
 ]
 
 [[package]]
@@ -1091,6 +1097,106 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
 name = "signalhub"
 version = "0.1.0"
 source = { git = "https://github.com/jaboll-ai/SignalHub.git?rev=pyproject#2d448869868687d1e4b0506153c8d6c6064d5997" }
@@ -1248,6 +1354,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Ziel
Vereinfachte Gesten-Datenerfassung: Jedes Teammitglied nimmt jeden der 26 Buchstaben **genau einmal** auf. Ein einziges geführtes CLI-Skript führt automatisch durch A–Z und legt die Daten direkt dort ab, wo das Training liest.

## Neu
- **`collect_alphabet.py`** – CLI-Einstieg für den geführten Aufnahme-Durchlauf (`python collect_alphabet.py --person <name>`).
- **`collect_alphabet()`** in `GestureRecognition/labeling.py` – führt durch alle 26 Buchstaben, speichert nach `recordings/<L>/<L>-<person>.pkl` (wo `dataset_building()` liest), mit **Resume** (bereits aufgenommene Buchstaben werden übersprungen) und Namensvalidierung.
- **`_record_one_take()`** – Einzelaufnahme-Logik aus `data_labeling` extrahiert (verhaltensgleich, von beiden genutzt).
- **`docs/alphabet-collection.md`** + README-Abschnitt – Workflow & Fehlerbehebung.

## Pipeline-Fixes (Recording lief vorher nicht end-to-end)
- `config.yml`: fehlende `recorder.record`-Liste ergänzt (sonst `record_list is None`).
- `demo.py`: `Webcam()` für Record-/Live-Modus aktiviert (war auskommentiert → schwarzes Fenster); Replay bleibt webcam-frei.
- `trailmarker.py` + `preprocessor.py`: `get_nested_key` auf die Dot-String-Signatur umgestellt (wie `HandDetector` / installiertes SignalHub) → behebt `'dict' object has no attribute 'split'`.

## Stabilität
`data_labeling`, `dataset_building`, `clean_recordings` und die Pipeline-Logik bleiben funktional unverändert. Aufnahmen gehen erst in eine Temp-Datei und werden nur beim Speichern nach `recordings/` verschoben; ein Existenz-Check verhindert Überschreiben.

## Getestet
End-to-end auf macOS (Apple Silicon): Kamerafeed öffnet, Buchstabe A aufgenommen, `recordings/A/A-arian.pkl` erzeugt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)