### PR TITLE
fix: Visualisierung & Aufnahme-Pruefung der Gesten-Pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ data
 .training.py
 plots/
 reports/
+
+# Aussortierte (schlechte) Aufnahmen aus review_recordings.py
+recordings_rejected/

--- a/GestureRecognition/labeling.py
+++ b/GestureRecognition/labeling.py
@@ -38,12 +38,29 @@ def _extract_trajectory(recording: dict, finger_idx: int) -> np.ndarray | None:
 
     points = []
     for frame in frames:
-        det = frame.get("detector")
-        if det and len(det.hand_landmarks) > 0:
-            lm = det.hand_landmarks[0][finger_idx]
-            points.append([lm.x, lm.y])
-        else:
+        # Manche Frames sind None (z.B. wird das stop()-Ergebnis des Detectors
+        # mitgespeichert). Solche behandeln wir wie "keine Hand erkannt".
+        if not isinstance(frame, dict):
             points.append(None)
+            continue
+
+        det = frame.get("detector")
+        point = None  # Standard: in diesem Frame keine Hand gefunden
+
+        # Es gibt zwei Aufnahme-Formate -- wir unterstuetzen beide:
+        if hasattr(det, "hand_landmarks"):
+            # 1) Alte Aufnahmen: rohes MediaPipe-Objekt (hat .hand_landmarks)
+            if len(det.hand_landmarks) > 0:
+                lm = det.hand_landmarks[0][finger_idx]
+                point = [lm.x, lm.y]
+        elif isinstance(det, dict):
+            # 2) Neue Aufnahmen: einfaches Dict {"hands": [{"landmarks": [...]}]}
+            hands = det.get("hands", [])
+            if hands:
+                lm = hands[0]["landmarks"][finger_idx]
+                point = [lm["x"], lm["y"]]
+
+        points.append(point)
 
     # Anfang und Ende ohne Hand abschneiden
     start = 0

--- a/GestureRecognition/modules/handdetector.py
+++ b/GestureRecognition/modules/handdetector.py
@@ -191,6 +191,17 @@ class HandDetector(Module):
         if image is None:
             return {"detector": {"hands": []}, "galy": galy}
 
+        # MediaPipe gibt jeden Punkt als Zahl zwischen 0 und 1 zurueck (also
+        # relativ zur Bildgroesse). GALY zeichnet aber in echten Pixeln. Wir
+        # muessen die Punkte also umrechnen: x mal Bildbreite, y mal Bildhoehe.
+        # GALY uebernimmt das automatisch, wenn wir ihm diese kleine Matrix geben.
+        height, width = image.shape[:2]
+        mapping = np.array([
+            [width, 0.0, 0.0],   # neues x = Breite * x
+            [0.0, height, 0.0],  # neues y = Hoehe  * y
+        ], dtype=np.float64)
+        galy.set_layer_affine_mapping(mapping)
+
         rgb_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb_image)
 

--- a/GestureRecognition/modules/trailmarker.py
+++ b/GestureRecognition/modules/trailmarker.py
@@ -1,5 +1,6 @@
 from SignalHub import Module, get_nested_key, GALY
 from collections import deque
+import numpy as np
 
 class TrailMarker(Module):
     """
@@ -171,7 +172,16 @@ class TrailMarker(Module):
             ``return { ..., "galy": galy}``
         """
         galy = GALY()
-        
+        # Wir zeichnen die Spur auf einen eigenen Layer namens "trail".
+        galy.layer("trail")
+        # Die Fingerpunkte sind Zahlen zwischen 0 und 1, GALY zeichnet in Pixeln.
+        # Also dieselbe Umrechnung wie im HandDetector: x mal Breite, y mal Hoehe.
+        mapping = np.array([
+            [self.webcam_width, 0.0, 0.0],
+            [0.0, self.webcam_height, 0.0],
+        ], dtype=np.float64)
+        galy.set_layer_affine_mapping(mapping)
+
         detector = data.get('detector', {})
         hands = detector.get('hands', [])
         
@@ -179,6 +189,11 @@ class TrailMarker(Module):
             hand = hands[0]  # Assume first hand
             landmarks = hand.get('landmarks', [])
             if len(landmarks) > self.finger_idx:
+                # War die Hand laenger als max_lost weg, ist das eine NEUE Geste:
+                # die eingefrorene Spur der vorigen Geste jetzt zuruecksetzen,
+                # bevor die neue beginnt.
+                if self.lost_counter > self.max_lost:
+                    self.trail.clear()
                 # Extract current finger position
                 pos = (landmarks[self.finger_idx]['x'], landmarks[self.finger_idx]['y'])
                 # Add to deque
@@ -191,11 +206,12 @@ class TrailMarker(Module):
         else:
             # No hand detected, increment lost counter
             self.lost_counter += 1
-        
-        # Behavior on tracking loss: If lost for more than max_lost frames, reset trail
-        if self.lost_counter > self.max_lost:
-            self.trail.clear()
-        
+
+        # Die Spur bleibt absichtlich stehen, wenn die Hand das Bild verlaesst --
+        # so sieht der Aufnehmer den fertig gezeichneten Buchstaben und kann
+        # beurteilen, ob die Aufnahme gut war. Zurueckgesetzt wird erst, wenn eine
+        # neue Geste beginnt (siehe oben: Hand kommt nach >max_lost Frames zurueck).
+
         # Draw lines between consecutive points
         if len(self.trail) > 1:
             for i in range(1, len(self.trail)):

--- a/README.md
+++ b/README.md
@@ -145,12 +145,22 @@ data/
 - Die Nummer `{i}` zaehlt fortlaufend hoch. Bestehende Aufnahmen werden nie
   ueberschrieben.
 
-## Alphabet-Sammlung im Team (A–Z, 1× pro Person)
+## Alphabet-Sammlung im Team (A–Z)
 
 Damit das Team schnell und reibungslos Trainingsdaten sammeln kann, gibt es ein
 geführtes Skript, das eine Person automatisch durch **alle 26 Buchstaben** führt
-und je **eine** Aufnahme pro Buchstabe macht. Die Aufnahmen landen direkt in
-`recordings/<Buchstabe>/` — also genau dort, wo `dataset_building()` liest.
+und pro Buchstabe **mehrere** Aufnahmen macht (Standard: 15). Die Aufnahmen
+landen direkt in `recordings/<Buchstabe>/` — also genau dort, wo
+`dataset_building()` liest.
+
+> **Vor dem ersten Lauf** unbedingt den Webcam-Index setzen (siehe
+> [Schritt 5](#5-webcam-index-einstellen)), sonst bleibt das Fenster schwarz.
+> `deviceIndex` ist pro Rechner unterschiedlich — diese lokale Einstellung
+> **nicht** committen. Auf macOS außerdem vorher den Qt-Pfad setzen, sonst
+> crasht das Fenster:
+> ```bash
+> export QT_QPA_PLATFORM_PLUGIN_PATH=$(python -c "import PyQt5, os; print(os.path.join(os.path.dirname(PyQt5.__file__), 'Qt5', 'plugins', 'platforms'))")
+> ```
 
 ### Aufruf
 
@@ -158,24 +168,48 @@ und je **eine** Aufnahme pro Buchstabe macht. Die Aufnahmen landen direkt in
 python collect_alphabet.py --person arian
 # oder ohne Argument, dann wird der Name abgefragt:
 python collect_alphabet.py
+# Anzahl Aufnahmen pro Buchstabe anpassen (Standard 15):
+python collect_alphabet.py --person arian --times 15
 ```
 
-- Pro Buchstabe: ENTER → Geste ausführen → Fenster schließen → `s`/`v`/`a`
-  (speichern / verwerfen / abbrechen) wie beim normalen Labeling.
-- **Resume:** Buchstaben, die diese Person schon aufgenommen hat, werden
-  übersprungen. Der Durchlauf kann jederzeit abgebrochen und später fortgesetzt
-  werden — nichts wird überschrieben.
+- Pro Buchstabe: ENTER → Geste in die Luft malen → Fenster schließen →
+  `s`/`v`/`a` (speichern / verwerfen / abbrechen).
+- Die gezeichnete Spur **bleibt stehen**, wenn die Hand das Bild verlässt — so
+  siehst du den fertigen Buchstaben und erkennst sofort, ob die Aufnahme sauber
+  war (ein wilder Querstrich = Tracking-Sprung = lieber `v`).
+- **Resume:** Bereits aufgenommene Takes dieser Person werden übersprungen. Der
+  Durchlauf kann jederzeit abgebrochen und später fortgesetzt werden — nichts
+  wird überschrieben.
 
 ### Dateibenennung
 
-Jede Aufnahme heißt `recordings/<Buchstabe>/<Buchstabe>-<person>.pkl`
-(z. B. `recordings/A/A-arian.pkl`). So ist nachvollziehbar, dass jedes
-Teammitglied jeden Buchstaben genau einmal aufgenommen hat, und Doppelungen
-derselben Person werden verhindert.
+Jede Aufnahme heißt `recordings/<Buchstabe>/<Buchstabe>-<person>-<n>.pkl`
+(z. B. `recordings/A/A-arian-1.pkl`). So bleibt nachvollziehbar, wer welche
+Aufnahmen gemacht hat, und nichts wird überschrieben.
+
+### Aufnahmen prüfen & aussortieren
+
+Nicht jede Aufnahme ist brauchbar (zu kurz, Tracking-Sprung, Hand kurz
+verloren). `review_recordings.py` prüft alle eigenen Aufnahmen mit **denselben
+Kriterien wie `dataset_building`** und verschiebt schlechte optional nach
+`recordings_rejected/` (löscht nichts):
+
+```bash
+python review_recordings.py --person arian              # nur Bericht
+python review_recordings.py --person arian --quarantine # schlechte aussortieren
+```
+
+Workflow bis z. B. 15 gute Aufnahmen pro Buchstabe:
+
+```bash
+python collect_alphabet.py --person arian               # fehlende nachnehmen
+python review_recordings.py --person arian --quarantine # prüfen & aussortieren
+# wiederholen, bis "fehlt 0"
+```
 
 ### Danach: Datensatz bauen
 
-Sind alle vier Personen durch, einmalig den Trainingsdatensatz erzeugen:
+Sind alle Personen durch, einmalig den Trainingsdatensatz erzeugen:
 
 ```bash
 python -c "from GestureRecognition.labeling import dataset_building; dataset_building('data/dataset.pkl')"

--- a/config.yml
+++ b/config.yml
@@ -33,4 +33,4 @@ hiddenmarkov:
 trailmarker:
   finger_idx: 8
   max_lost: 10
-  max_trail_length: 50
+  max_trail_length: 300

--- a/docs/recording-pipeline-fixes.md
+++ b/docs/recording-pipeline-fixes.md
@@ -1,0 +1,58 @@
+# Visualisierung & Aufnahme-Pruefung (Fixes + Tool)
+
+Dieses Dokument erklaert kurz, **was** geaendert wurde und **warum**. Es ging
+darum, das Aufnehmen der Buchstaben tatsaechlich benutzbar zu machen.
+
+## Hintergrund: normalisierte Punkte vs. Pixel
+
+MediaPipe gibt jeden Handpunkt als Zahl zwischen `0` und `1` zurueck (relativ
+zur Bildgroesse). GALY zeichnet aber in **echten Pixeln**. Wenn man die `0..1`-
+Werte direkt zeichnet, landet alles in der Ecke bei Pixel `(0, 0)` und ist
+unsichtbar. Loesung: dem Layer eine kleine Umrechnung mitgeben
+(`set_layer_affine_mapping`), die `x` mit der Bildbreite und `y` mit der
+Bildhoehe multipliziert.
+
+## Behobene Fehler
+
+1. **Hand-Skelett unsichtbar** – `HandDetector` ([modules/handdetector.py](../GestureRecognition/modules/handdetector.py))
+   setzt jetzt das Pixel-Mapping fuer den `hands`-Layer.
+2. **Bewegungs-Spur unsichtbar** – `TrailMarker` ([modules/trailmarker.py](../GestureRecognition/modules/trailmarker.py))
+   nutzt einen eigenen Layer `trail` mit demselben Mapping (der Layer wird pro
+   Frame zurueckgesetzt, darum muss er explizit gesetzt werden).
+3. **`dataset_building` stuerzt bei neuen Aufnahmen ab** –
+   `_extract_trajectory` ([labeling.py](../GestureRecognition/labeling.py))
+   liest jetzt **beide** Aufnahme-Formate (altes rohes MediaPipe-Objekt **und**
+   das neue Dict des aktuellen Detectors) und ueberspringt `None`-Frames (das
+   `stop()`-Ergebnis des Detectors wird mitgespeichert).
+
+## Verbesserung: Spur bleibt stehen
+
+Die Spur wird **nicht mehr geloescht, wenn die Hand das Bild verlaesst**. So
+sieht man als Aufnehmer den fertig gezeichneten Buchstaben und erkennt sofort,
+ob die Aufnahme sauber war (ein wilder Querstrich = Tracking-Sprung = schlecht).
+Zurueckgesetzt wird erst, wenn eine neue Geste beginnt. Zusaetzlich wurde
+`max_trail_length` in [config.yml](../config.yml) von `50` auf `300` erhoeht,
+damit der ganze Buchstabe sichtbar bleibt.
+
+> Hinweis: `webcam.deviceIndex` ist pro Rechner unterschiedlich. Falls das Bild
+> schwarz bleibt, den richtigen Index ermitteln (siehe README) und lokal in
+> `config.yml` eintragen – diese Aenderung **nicht** committen.
+
+## Tool: Aufnahmen pruefen
+
+`review_recordings.py` prueft alle eigenen Aufnahmen mit **denselben Kriterien
+wie `dataset_building`** (Mindestlaenge, keine Tracking-Spruenge, kein NaN) und
+verschiebt schlechte optional in `recordings_rejected/` (loescht nichts).
+
+```bash
+python review_recordings.py --person <name>              # nur Bericht
+python review_recordings.py --person <name> --quarantine # schlechte aussortieren
+```
+
+Workflow zum Auffuellen auf z.B. 15 gute pro Buchstabe:
+
+```bash
+python collect_alphabet.py --person <name>               # fehlende nachnehmen
+python review_recordings.py --person <name> --quarantine # pruefen & aussortieren
+# wiederholen, bis "fehlt 0"
+```

--- a/review_recordings.py
+++ b/review_recordings.py
@@ -1,0 +1,159 @@
+"""
+Prueft die aufgenommenen Gesten und sortiert unbrauchbare aus.
+
+Eine Aufnahme ist nur dann brauchbar, wenn sie spaeter auch wirklich im
+Datensatz landet. Darum pruefen wir hier genau dasselbe wie ``dataset_building``:
+
+  1. Lang genug?      -> mindestens ``min_length`` Frames (nach dem Trimmen
+                         der Frames ohne Hand am Anfang/Ende)
+  2. Keine Spruenge?  -> kein Sprung der Fingerspitze > ``max_jump`` von einem
+                         Frame zum naechsten (typischer Tracking-Fehler)
+  3. Keine Luecke?    -> kein NaN mitten in der Bewegung (Hand kurz verloren)
+
+Es werden NUR die eigenen Aufnahmen einer Person angefasst, also Dateien wie
+``A-yannik-1.pkl``. Die geteilten Team-Altdaten (``A-1773050612....pkl``)
+bleiben unberuehrt.
+
+Benutzung
+---------
+    python review_recordings.py --person yannik              # nur anschauen
+    python review_recordings.py --person yannik --quarantine # schlechte verschieben
+"""
+
+import argparse
+import pickle
+import shutil
+from pathlib import Path
+
+import numpy as np
+
+from GestureRecognition.labeling import _extract_trajectory, _is_outlier, ALPHABET
+
+
+def biggest_jump(traj):
+    """Gibt den groessten Abstand zwischen zwei aufeinanderfolgenden Punkten zurueck."""
+    # Nur die Punkte nehmen, an denen die Hand erkannt wurde (keine NaN).
+    valid = traj[~np.isnan(traj).any(axis=1)]
+    groesster = 0.0
+    for i in range(1, len(valid)):
+        abstand = float(np.linalg.norm(valid[i] - valid[i - 1]))
+        if abstand > groesster:
+            groesster = abstand
+    return groesster
+
+
+def check_recording(path, finger_idx, min_length, max_jump):
+    """
+    Prueft eine einzelne Aufnahme.
+
+    Gibt (ok, grund) zurueck:
+      ok    -> True, wenn die Aufnahme brauchbar ist
+      grund -> "OK" oder warum sie verworfen wird
+    """
+    with open(path, "rb") as f:
+        recording = pickle.load(f)
+
+    # Die Fingerspitzen-Bewegung aus der Aufnahme holen.
+    traj = _extract_trajectory(recording, finger_idx)
+
+    if traj is None:
+        return False, "keine Hand erkannt"
+    if len(traj) < min_length:
+        return False, f"zu kurz ({len(traj)} < {min_length} Frames)"
+    if _is_outlier(traj, max_jump):
+        return False, f"Tracking-Sprung ({biggest_jump(traj):.3f})"
+    if np.isnan(traj).any():
+        return False, "NaN mittendrin (Hand kurz verloren)"
+    return True, "OK"
+
+
+def find_person_files(label_dir, letter, person):
+    """Alle Aufnahme-Dateien einer Person fuer einen Buchstaben finden."""
+    files = sorted(label_dir.glob(f"{letter}-{person}-*.pkl"))
+    # Aeltere Aufnahmen hatten evtl. keine Nummer (z.B. A-yannik.pkl).
+    legacy = label_dir / f"{letter}-{person}.pkl"
+    if legacy.exists():
+        files.append(legacy)
+    return files
+
+
+def move_to_quarantine(path, quarantine_dir, letter):
+    """Verschiebt eine schlechte Aufnahme in den Quarantaene-Ordner (loescht nichts)."""
+    ziel_ordner = quarantine_dir / letter
+    ziel_ordner.mkdir(parents=True, exist_ok=True)
+    ziel = ziel_ordner / path.name
+    # Falls dort schon eine Datei mit dem Namen liegt: eine Nummer anhaengen.
+    nummer = 1
+    while ziel.exists():
+        ziel = ziel_ordner / f"{path.stem}__{nummer}{path.suffix}"
+        nummer += 1
+    shutil.move(str(path), str(ziel))
+
+
+def main():
+    parser = argparse.ArgumentParser("Aufnahmen pruefen und schlechte aussortieren")
+    parser.add_argument("--person", required=True, help="Name / Kuerzel (wie bei der Aufnahme)")
+    parser.add_argument("--recordings-dir", default="recordings")
+    parser.add_argument("--quarantine-dir", default="recordings_rejected")
+    parser.add_argument("--finger-idx", type=int, default=8)
+    parser.add_argument("--min-length", type=int, default=15)
+    parser.add_argument("--max-jump", type=float, default=0.15)
+    parser.add_argument("--target", type=int, default=15,
+                        help="Gewuenschte Anzahl guter Aufnahmen pro Buchstabe")
+    parser.add_argument("--quarantine", action="store_true",
+                        help="Schlechte wirklich verschieben (ohne dieses Flag nur anzeigen)")
+    args = parser.parse_args()
+
+    recordings_dir = Path(args.recordings_dir)
+    quarantine_dir = Path(args.quarantine_dir)
+    person = args.person.strip()
+
+    if args.quarantine:
+        print(f"Pruefe Aufnahmen von '{person}' -- schlechte werden verschoben.")
+    else:
+        print(f"Pruefe Aufnahmen von '{person}' -- nur Anzeige (nichts wird veraendert).")
+    print(f"{'Buchstabe':<10}{'gut':>5}{'gesamt':>8}{'fehlt':>7}   verworfen")
+    print("-" * 60)
+
+    summe_gut = 0
+    summe_fehlt = 0
+
+    # Jeden Buchstaben A-Z durchgehen.
+    for letter in ALPHABET:
+        label_dir = recordings_dir / letter
+        if not label_dir.is_dir():
+            continue
+
+        files = find_person_files(label_dir, letter, person)
+        if not files:
+            continue  # diesen Buchstaben hat die Person noch nicht aufgenommen
+
+        gute = 0
+        verworfen = []
+        for path in files:
+            ok, grund = check_recording(path, args.finger_idx, args.min_length, args.max_jump)
+            if ok:
+                gute += 1
+            else:
+                verworfen.append((path, grund))
+                if args.quarantine:
+                    move_to_quarantine(path, quarantine_dir, letter)
+
+        fehlt = max(0, args.target - gute)
+        summe_gut += gute
+        summe_fehlt += fehlt
+
+        text = ", ".join(f"{p.name}: {g}" for p, g in verworfen) if verworfen else "-"
+        print(f"{letter:<10}{gute:>5}{len(files):>8}{fehlt:>7}   {text}")
+
+    print("-" * 60)
+    print(f"Gute Aufnahmen gesamt: {summe_gut}")
+    if summe_fehlt > 0:
+        print(f"Noch nachzunehmen bis Ziel {args.target}: {summe_fehlt} Aufnahme(n).")
+        print("=> einfach collect_alphabet.py erneut starten.")
+    else:
+        print(f"Alle aufgenommenen Buchstaben haben das Ziel von {args.target} erreicht.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Worum geht's

Beim Aufnehmen der Buchstaben sind mehrere Probleme aufgetaucht, die das Sammeln von Trainingsdaten praktisch unmoeglich gemacht haben. Dieser PR behebt sie und ergaenzt ein kleines Tool, mit dem man Aufnahmen vor dem Training pruefen kann.

## Hintergrund

MediaPipe liefert Handpunkte als Werte zwischen `0` und `1` (relativ zur Bildgroesse), GALY zeichnet aber in **echten Pixeln**. Ohne Umrechnung landet alles bei Pixel `(0,0)` und ist unsichtbar. Loesung: dem Layer ein `set_layer_affine_mapping` geben, das `x` mit der Breite und `y` mit der Hoehe multipliziert.

## Behobene Fehler

- **Hand-Skelett unsichtbar** (`HandDetector`): Pixel-Mapping fuer den `hands`-Layer ergaenzt.
- **Bewegungs-Spur unsichtbar** (`TrailMarker`): eigener Layer `trail` mit demselben Mapping.
- **`dataset_building` crasht bei neuen Aufnahmen** (`labeling._extract_trajectory`): liest jetzt **beide** Aufnahme-Formate (altes rohes MediaPipe-Objekt + neues Dict des aktuellen Detectors) und ueberspringt `None`-Frames (das `stop()`-Ergebnis des Detectors wird mitgespeichert).

## Verbesserung

- **Spur bleibt stehen**, wenn die Hand das Bild verlaesst (Reset erst bei neuer Geste) -> man sieht den fertigen Buchstaben und erkennt Tracking-Spruenge sofort.
- `config.yml`: `max_trail_length` 50 -> 300, damit der ganze Buchstabe sichtbar bleibt.

## Neu: `review_recordings.py`

Prueft alle eigenen Aufnahmen mit **denselben Kriterien wie `dataset_building`** (Mindestlaenge, keine Tracking-Spruenge, kein NaN) und verschiebt schlechte optional nach `recordings_rejected/` (loescht nichts, nur eigene `*-<person>-*`-Dateien).

```bash
python review_recordings.py --person <name>              # nur Bericht
python review_recordings.py --person <name> --quarantine # schlechte aussortieren
```

## Hinweise fuer Reviewer

- `webcam.deviceIndex` ist **bewusst nicht** geaendert (ist pro Rechner unterschiedlich).
- Aufnahme-Dateien (`recordings/`) sind **nicht** Teil dieses PRs -- nur Code/Tool/Doku.
- Details: `docs/recording-pipeline-fixes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)