### PR TITLE
Live-Klassifikation lauffähig: Preprocessor-Feature-Fix + HMM-Train-Skript + Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ reports/
 
 # Aussortierte (schlechte) Aufnahmen aus review_recordings.py
 recordings_rejected/
+
+# macOS
+.DS_Store
+
+# Versehentlich eingecheckter, verschachtelter Repo-Klon (Phantom-Gitlink)
+/GestureRecognitionMPT/

--- a/GestureRecognition/labeling.py
+++ b/GestureRecognition/labeling.py
@@ -697,6 +697,23 @@ def dataset_building(
             "Bereinigungs-Parameter (min_length, max_jump) lockern."
         )
 
+    # Zusaetzlich zur Pro-Klasse-Pruefung braucht der stratifizierte Split von
+    # sklearn, dass BEIDE Seiten (Train und Test) mindestens so viele Sequenzen
+    # bekommen wie es Klassen gibt. Sonst bricht train_test_split mit einer
+    # schwer verstaendlichen Meldung ab -- typisch waehrend der Datensammlung:
+    # viele Klassen (A-Z) mit noch wenigen Aufnahmen pro Klasse.
+    n_classes = len(class_counts)
+    n_test = int(np.ceil(test_size * len(sequences)))
+    n_train = len(sequences) - n_test
+    if min(n_train, n_test) < n_classes:
+        needed = int(np.ceil(n_classes / min(test_size, 1 - test_size)))
+        raise ValueError(
+            f"Zu wenige Aufnahmen fuer einen stratifizierten Train/Test-Split "
+            f"ueber {n_classes} Klassen (Train {n_train}, Test {n_test} Sequenzen; "
+            f"beide muessen >= {n_classes} sein). Bitte insgesamt mindestens "
+            f"{needed} gueltige Aufnahmen erstellen oder test_size anpassen."
+        )
+
     indices = np.arange(len(sequences))
     train_idx, test_idx = train_test_split(
         indices, test_size=test_size, stratify=labels, random_state=random_state

--- a/GestureRecognition/modules/preprocessor.py
+++ b/GestureRecognition/modules/preprocessor.py
@@ -109,8 +109,11 @@ class Preprocessor(Module):
         # As a beginner student programmer, I need to initialize the module's state here.
         # First, I read the configuration values from the config signal.
         # I use get_nested_key to access nested config values safely.
-        # The finger_index specifies which finger landmark to track, default is 8 for index finger tip.
-        self.finger_index = get_nested_key("config.preprocessor.finger_index", data, 8)
+        # finger_idx legt fest, welches Hand-Landmark verfolgt wird (Default 8 = Zeigefingerspitze).
+        # WICHTIG: Der Schluessel heisst finger_idx -- genau wie in config.yml, im Training
+        # (labeling.py) und im TrailMarker. Nur mit exakt gleichem Schluessel verfolgen Training
+        # und Live denselben Finger; ein abweichender Name wuerde still auf den Default zurueckfallen.
+        self.finger_idx = get_nested_key("config.preprocessor.finger_idx", data, 8)
         # buffer_size is the maximum number of points to store in the trajectory buffer.
         self.buffer_size = get_nested_key("config.preprocessor.buffer_size", data, 30)
         # min_steps is the minimum number of points needed for a valid trajectory.
@@ -197,7 +200,7 @@ class Preprocessor(Module):
         if detector and detector.get('hands'):
             # If a hand is detected, extract the finger position.
             hand = detector['hands'][0]  # Assume the first hand.
-            landmark = hand['landmarks'][self.finger_index]
+            landmark = hand['landmarks'][self.finger_idx]
             pos = np.array([landmark['x'], landmark['y']])
             # Append the position to the buffer.
             self.buffer.append(pos)

--- a/GestureRecognition/modules/preprocessor.py
+++ b/GestureRecognition/modules/preprocessor.py
@@ -238,36 +238,47 @@ class Preprocessor(Module):
 
     def process_trajectory(self):
         """
-        Process the collected trajectory: normalize and add velocity features.
-        
-        Normalization strategy: Centering by subtracting the mean to center the trajectory around the origin,
-        making it translation-invariant. Scaling by dividing by standard deviation + epsilon (1e-8) to make it 
-        scale-invariant and stable against static trajectories where std=0.
-        
-        Used features: (x, y, dx, dy) representation, where x,y are normalized positions and dx,dy are velocities 
-        computed using np.diff. This captures both spatial position and temporal motion for better gesture recognition.
-        
-        Threshold choices: min_steps=10 ensures a minimum trajectory length for meaningful analysis; max_lost=5 allows 
-        brief hand losses without discarding the gesture; min_speed_corner=0.01 and reset_speed_corner=0.005 provide 
-        hysteresis to robustly detect gesture start and end based on movement speed.
+        Bereitet die gesammelte Trajektorie so auf, dass sie exakt zum
+        Trainingsformat passt.
+
+        Warum das wichtig ist
+        ---------------------
+        Der Klassifikator wird in
+        :func:`GestureRecognition.labeling.dataset_building` (ueber
+        :func:`clean_recordings`) auf Sequenzen der Form ``(N, 3)`` mit den
+        Spalten ``(x, y, velocity)`` trainiert. Damit die hier live erzeugte
+        Trajektorie vom Modell bewertet werden kann, muss sie im selben Format
+        vorliegen -- sonst passt die Feature-Dimension nicht und das Modell
+        liefert keinen sinnvollen Score.
+
+        Deshalb nutzen wir hier genau dieselben zwei Schritte wie das Training
+        und rufen dessen Funktionen direkt auf (eine einzige Quelle der Wahrheit
+        -- Live und Training koennen so nie wieder auseinanderlaufen):
+
+        1. ``_normalize``    -- zentrieren + auf den Einheitskreis skalieren -> ``(x, y)``
+        2. ``_add_velocity`` -- Geschwindigkeit (Abstand zum Vorframe) als
+           dritte Spalte anhaengen -> ``(x, y, velocity)``
+
+        Returns
+        -------
+        np.ndarray
+            Trajektorie der Form ``(N, 3)`` mit den Spalten ``(x, y, velocity)``.
         """
-        # Convert buffer to numpy array.
-        trajectory = np.array(list(self.buffer))
-        # Centering: subtract the mean.
-        mean = np.mean(trajectory, axis=0)
-        trajectory -= mean
-        # Scaling: divide by std + epsilon to avoid division by zero.
-        std = np.std(trajectory, axis=0) + 1e-8
-        trajectory /= std
-        # Velocity features: use np.diff to get differences.
-        if len(trajectory) > 1:
-            diffs = np.diff(trajectory, axis=0)
-            # Combine positions and velocities: (x, y, dx, dy)
-            features = np.column_stack((trajectory[:-1], diffs))
-        else:
-            # If only one point, just return it (though min_steps should prevent this).
-            features = trajectory
-        # Clear the buffer for next gesture.
+        # Die beiden Aufbereitungsschritte des Trainings wiederverwenden. Der
+        # Import steht bewusst hier in der Funktion: So wird die nur fuers
+        # Training benoetigte labeling-Abhaengigkeit erst beim Abschluss einer
+        # Geste geladen und belastet den Start der Live-Pipeline nicht.
+        from GestureRecognition.labeling import _normalize, _add_velocity
+
+        # Rohe (x, y)-Punkte aus dem Puffer als NumPy-Array holen.
+        trajectory = np.array(list(self.buffer), dtype=float)
+
+        # 1) Zentrieren + auf den Einheitskreis skalieren -> (x, y).
+        trajectory = _normalize(trajectory)
+        # 2) Geschwindigkeit als dritte Spalte anhaengen -> (x, y, velocity).
+        features = _add_velocity(trajectory)
+
+        # Puffer fuer die naechste Geste leeren.
         self.buffer.clear()
         return features
 

--- a/train.py
+++ b/train.py
@@ -1,0 +1,173 @@
+"""
+Trainiert den HMM-Klassifikator auf den aufgenommenen Gesten und speichert ihn.
+
+Ablauf (siehe Doku "Fit/Train HMM Classifier")
+----------------------------------------------
+1. ``dataset_building()`` -- baut aus ``recordings/`` einen Datensatz im Format
+   ``(x, y, velocity)`` und teilt ihn stratifiziert in Train/Test (sequenzweise,
+   also ohne Data-Leakage).
+2. ``HMMClassifier.fit()`` -- trainiert ein eigenes HMM pro Klasse auf dem
+   Train-Split.
+3. Auswertung auf dem Test-Split (Accuracy) -- Test ist sauber vom Training
+   getrennt, sonst waeren die Zahlen nicht aussagekraeftig.
+4. ``.save()`` -- legt das Modell unter ``data/hmm.pkl`` ab, also genau dort,
+   wo das :class:`HMMModule` es im Live-/Replay-Betrieb per Default laedt.
+
+Das Trainingsformat ``(x, y, velocity)`` ist identisch zu dem, was der
+Preprocessor live erzeugt -- nur so passt Training zu Inferenz.
+
+Benutzung
+---------
+    python train.py                    # Standard: recordings/ -> data/hmm.pkl
+    python train.py --grid-search      # bestes n_components per Cross-Validation
+    python train.py --n-components 5   # feste Zustandszahl vorgeben
+"""
+
+import argparse
+import logging
+
+from GestureRecognition.hmmclassifier import HMMClassifier
+from GestureRecognition.labeling import dataset_building
+
+logger = logging.getLogger(__name__)
+
+
+def _split_sequences(X, lengths):
+    """Zerlegt ein konkateniertes ``(total_frames, n_features)``-Array anhand von
+    ``lengths`` wieder in eine Liste einzelner Sequenzen.
+
+    Die Grid-Search arbeitet auf einzelnen Sequenzen, ``dataset_building`` liefert
+    aber ein zusammengehaengtes Array plus Laengenliste. Diese Hilfsfunktion baut
+    die Sequenzen daraus zurueck.
+    """
+    sequences = []
+    offset = 0
+    for length in lengths:
+        sequences.append(X[offset:offset + length])
+        offset += length
+    return sequences
+
+
+def _accuracy(y_true, y_pred):
+    """Anteil korrekter Vorhersagen (einfache Klassifikationsgenauigkeit)."""
+    y_true = list(y_true)
+    if not y_true:
+        return 0.0
+    correct = sum(true == pred for true, pred in zip(y_true, y_pred))
+    return correct / len(y_true)
+
+
+def train(
+    recordings_dir="recordings",
+    model_path="data/hmm.pkl",
+    dataset_path="data/dataset.pkl",
+    n_components=4,
+    use_grid_search=False,
+    test_size=0.2,
+    random_state=42,
+):
+    """Baut den Datensatz, trainiert den Klassifikator und speichert ihn.
+
+    Returns
+    -------
+    HMMClassifier
+        Das trainierte Modell (zusaetzlich unter ``model_path`` gespeichert).
+    """
+    # 1) Datensatz bauen: bereinigen, Features extrahieren, Train/Test-Split.
+    logger.info("Baue Datensatz aus '%s' ...", recordings_dir)
+    data = dataset_building(
+        dataset_path,
+        recordings_dir=recordings_dir,
+        test_size=test_size,
+        random_state=random_state,
+    )
+    X_train, y_train, lengths_train = data["X_train"], data["y_train"], data["lengths_train"]
+    X_test, y_test, lengths_test = data["X_test"], data["y_test"], data["lengths_test"]
+    classes = data["classes"]
+    logger.info(
+        "Klassen (%d): %s | Train-Sequenzen: %d | Test-Sequenzen: %d",
+        len(classes), classes, len(lengths_train), len(lengths_test),
+    )
+
+    # 2) Optional: bestes n_components per Cross-Validation auf dem Train-Split
+    #    bestimmen. Der Import steht bewusst hier, damit die (nur dafuer noetige)
+    #    matplotlib-Abhaengigkeit den Standardlauf nicht belastet.
+    if use_grid_search:
+        from GestureRecognition.grid_search import grid_search_n_components
+
+        logger.info("Grid-Search fuer n_components (Cross-Validation) ...")
+        train_sequences = _split_sequences(X_train, lengths_train)
+        _, best = grid_search_n_components(train_sequences, list(y_train))
+        n_components = best["n_components"]
+        logger.info(
+            "Bestes n_components = %d (CV-Accuracy %.3f)",
+            n_components, best["mean_accuracy"],
+        )
+
+    # 3) Finales Modell auf dem kompletten Train-Split trainieren.
+    logger.info("Trainiere HMMClassifier (n_components=%d) ...", n_components)
+    classifier = HMMClassifier(n_components=n_components, random_state=random_state)
+    classifier.fit(X_train, y_train, lengths_train)
+
+    # 4) Auf dem Test-Split auswerten -- Test ist getrennt vom Training.
+    if len(lengths_test) > 0:
+        predictions = classifier.predict(X_test, lengths_test)
+        accuracy = _accuracy(y_test, predictions)
+        logger.info(
+            "Test-Accuracy: %.3f  (%d Test-Sequenzen)", accuracy, len(lengths_test)
+        )
+    else:
+        logger.warning("Kein Test-Split vorhanden -- Accuracy nicht berechenbar.")
+
+    # 5) Modell speichern -- genau dorthin, wo das HMMModule es per Default laedt.
+    classifier.save(model_path)
+    logger.info("Fertig. Modell gespeichert unter '%s'.", model_path)
+    return classifier
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="HMM-Klassifikator trainieren und als data/hmm.pkl speichern"
+    )
+    parser.add_argument(
+        "--recordings-dir", default="recordings",
+        help="Ordner mit den Aufnahmen (Standard: recordings)",
+    )
+    parser.add_argument(
+        "--model-out", default="data/hmm.pkl",
+        help="Zielpfad fuer das Modell (Standard: data/hmm.pkl)",
+    )
+    parser.add_argument(
+        "--dataset-out", default="data/dataset.pkl",
+        help="Zielpfad fuer den erzeugten Datensatz (Standard: data/dataset.pkl)",
+    )
+    parser.add_argument(
+        "--n-components", type=int, default=4,
+        help="Anzahl Zustaende pro HMM (Standard: 4)",
+    )
+    parser.add_argument(
+        "--grid-search", action="store_true",
+        help="bestes n_components per Cross-Validation suchen (ueberschreibt --n-components)",
+    )
+    parser.add_argument(
+        "--test-size", type=float, default=0.2,
+        help="Anteil des Test-Splits (Standard: 0.2)",
+    )
+    parser.add_argument("--random-state", type=int, default=42)
+    args = parser.parse_args()
+
+    train(
+        recordings_dir=args.recordings_dir,
+        model_path=args.model_out,
+        dataset_path=args.dataset_out,
+        n_components=args.n_components,
+        use_grid_search=args.grid_search,
+        test_size=args.test_size,
+        random_state=args.random_state,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Ziel

Macht die **Live-Gestenerkennung end-to-end lauffähig**. Vorher lieferte die Live-Pipeline immer „?", weil (a) der Preprocessor ein anderes Feature-Format als das Training erzeugte und (b) es kein trainiertes Modell / kein Trainings-Skript gab.

## Änderungen

**1. `fix(preprocessor)`: Feature-Format an Training angleichen** (`8d110bf`)
- `process_trajectory()` erzeugte `(x, y, dx, dy)` mit Std-Normalisierung, das Training baut aber `(x, y, velocity)` mit Einheitskreis-Normalisierung → `model.score()` scheiterte an der Dimension.
- Fix: `process_trajectory()` nutzt jetzt **dieselben Funktionen wie das Training** (`_normalize` + `_add_velocity` aus `labeling.py`) → byte-identisches `(N, 3)`-Format. Eine Quelle der Wahrheit.

**2. `fix(preprocessor)`: Config-Schlüssel `finger_idx`** (`2212c51`)
- `start()` las `config.preprocessor.finger_index`, überall sonst (config.yml, Training, TrailMarker) heißt der Schlüssel `finger_idx`. Der falsche Name fiel still auf den Default zurück → Train/Live-Landmine. Angeglichen.

**3. `feat(training)`: Train-&-Save-Skript + robuster Split-Guard** (`b08a00b`)
- Neues `train.py`: `dataset_building` → `HMMClassifier.fit` (ein HMM pro Klasse) → Auswertung auf getrenntem Test-Split (Accuracy) → speichert `data/hmm.pkl` (dort lädt es das `HMMModule`). Optional `--grid-search` (bestes `n_components` per Cross-Validation).
- `dataset_building` wirft jetzt bei zu wenigen Aufnahmen über viele Klassen eine **klare deutsche Meldung** statt des kryptischen sklearn-Fehlers (relevant beim Live-Aufnehmen A–Z mit noch wenigen Takes).

**4. `chore`: Cleanup** (`0e4ad42`)
- Phantom-Gitlink `GestureRecognitionMPT` (bogus Submodul, mode 160000, ohne `.gitmodules`) aus dem Index entfernt.
- `.gitignore` um `.DS_Store` und den Phantom-Ordner ergänzt.

## Verifikation

- ✅ Live-Output `==` Trainings-Output (byte-identisch, `(N, 3)` = `(x, y, velocity)`).
- ✅ `python train.py` → 26 Klassen, **Test-Accuracy 0.970** (67 Test-Sequenzen), `data/hmm.pkl` erzeugt.
- ✅ Echtes gespeichertes Modell bewertet eine live erzeugte Preprocessor-Sequenz mit **endlichem Score** (kein `-inf` mehr).
- ✅ Split-Guard: klare Meldung bei zu wenig Daten, normaler Ablauf bei genug.
- ✅ Adversarialer Multi-Agent-Review (4 Lenses + Gegenprüfung); alle bestätigten Findings in diesem PR behoben.

## Hinweise

- `data/` ist bereits in `.gitignore` → Modell/Datensatz werden **nicht** eingecheckt (reproduzierbar via `python train.py`).
- Nicht enthalten (bewusst): lokale Env-Tweaks in `config.yml`/`__init__.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
