### PR TITLE
chore: Phantom-Gitlink entfernen + .gitignore ergänzen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ reports/
 
 # Aussortierte (schlechte) Aufnahmen aus review_recordings.py
 recordings_rejected/
+
+# macOS
+.DS_Store
+
+# Versehentlich eingecheckter, verschachtelter Repo-Klon (Phantom-Gitlink)
+/GestureRecognitionMPT/


### PR DESCRIPTION
Repo-Hygiene:
- Phantom-Gitlink `GestureRecognitionMPT` (bogus Submodul, mode 160000, ohne `.gitmodules` — versehentlich eingecheckter, verschachtelter Repo-Klon) aus dem Index entfernt.
- `.gitignore` um `.DS_Store` und den Phantom-Ordner ergänzt.

Aus PR #35 herausgelöst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)