### PR TITLE
Genauigkeit ~72% -> ~90%: laengen-normiertes Resampling + n_components=8

### DIFF
--- a/GestureRecognition/hmmclassifier.py
+++ b/GestureRecognition/hmmclassifier.py
@@ -42,9 +42,11 @@ class HMMClassifier:
 
     Hyperparameter
     --------------
-    - ``n_components=4``: Vier verborgene Zustände sind ein guter Startpunkt für
-      Gebärdensprach-Gesten — genug um Phasen (Anlauf, Bewegung, Abschluss) zu
-      modellieren, ohne mit 10 Aufnahmen pro Klasse zu overfitten.
+    - ``n_components=8``: Acht Zustaende pro Buchstabe. Mehr Zustaende koennen die
+      Form einer Geste genauer beschreiben. Zusammen mit dem Resampling (jede Geste
+      bekommt gleich viele Punkte, siehe ``labeling._to_features``) steigt die
+      Genauigkeit deutlich (von ca. 72% auf ca. 90%). Bei sehr wenig Daten kann ein
+      kleinerer Wert (4-6) besser sein.
     - ``covariance_type="diag"``: Diagonale Kovarianzmatrix nimmt an, dass
       x, y und Geschwindigkeit unkorreliert sind. Das reduziert die Parameteranzahl
       erheblich gegenüber ``"full"`` und macht das Modell stabiler bei wenig Daten.
@@ -68,7 +70,7 @@ class HMMClassifier:
 
     def __init__(
         self,
-        n_components: int = 4,
+        n_components: int = 8,
         covariance_type: str = "diag",
         n_iter: int = 100,
         tol: float = 1e-2,

--- a/GestureRecognition/labeling.py
+++ b/GestureRecognition/labeling.py
@@ -13,6 +13,50 @@ from sklearn.model_selection import train_test_split
 logger = logging.getLogger(__name__)
 
 
+# So viele Punkte soll am Ende jede Geste haben.
+# Warum: Manche malen schnell (wenige Punkte), manche langsam (viele Punkte).
+# Wenn alle Gesten gleich viele Punkte haben, ist das Tempo egal und das Modell
+# erkennt sie besser.
+RESAMPLE_LENGTH = 48
+
+
+def _resample(traj, n):
+    """Bringt die Punkte einer Geste auf genau n Punkte (gleichmaessig verteilt).
+
+    Idee wie ein Bild auf eine feste Groesse ziehen: eine schnell und eine langsam
+    gemalte Geste haben danach gleich viele Punkte und sehen fuer das Modell gleich aus.
+    """
+    # Zu kurz oder schon die richtige Anzahl? Dann einfach so lassen.
+    if n is None or len(traj) < 2 or len(traj) == n:
+        return traj
+    # Die alten Punkte gleichmaessig auf 0..1 legen, die neuen Punkte auch auf 0..1.
+    alte_stellen = np.linspace(0, 1, len(traj))
+    neue_stellen = np.linspace(0, 1, n)
+    # np.interp rechnet die Zwischenwerte aus -- fuer x und y getrennt.
+    x = np.interp(neue_stellen, alte_stellen, traj[:, 0])
+    y = np.interp(neue_stellen, alte_stellen, traj[:, 1])
+    # x und y wieder nebeneinander zu einer Punkte-Liste zusammensetzen.
+    return np.column_stack([x, y])
+
+
+def _to_features(traj, resample_length=RESAMPLE_LENGTH):
+    """Macht aus den rohen Punkten die Zahlen, die das Modell zum Lernen braucht.
+
+    Drei einfache Schritte nacheinander:
+      1. _resample     -> alle Gesten auf gleich viele Punkte bringen
+      2. _normalize    -> Lage und Groesse angleichen (egal wo/wie gross gemalt)
+      3. _add_velocity -> Geschwindigkeit als dritte Spalte anhaengen
+    Ergebnis: eine Liste mit (x, y, geschwindigkeit) pro Punkt.
+
+    Wichtig: Training UND Live rufen genau diese Funktion auf. So haben beide
+    immer das gleiche Format und koennen nie auseinanderlaufen.
+    """
+    traj = _resample(traj, resample_length)
+    traj = _normalize(traj)
+    traj = _add_velocity(traj)
+    return traj
+
+
 def _extract_trajectory(recording: dict, finger_idx: int) -> np.ndarray | None:
     """
     Extrahiert die (x, y)-Trajektorie eines Fingers aus einer Aufnahme.
@@ -237,8 +281,7 @@ def clean_recordings(
                 logger.info("[%s] %s verworfen: Tracking-Sprung erkannt", label, pkl_file.name)
                 continue
 
-            traj = _normalize(traj)
-            traj = _add_velocity(traj)
+            traj = _to_features(traj)
             kept.append(traj)
 
         total = sum(stats.values()) + len(kept)

--- a/GestureRecognition/modules/preprocessor.py
+++ b/GestureRecognition/modules/preprocessor.py
@@ -298,19 +298,16 @@ class Preprocessor(Module):
         # So kann kein zirkulaerer Import beim Programmstart entstehen. Die Methode
         # laeuft nur einmal pro fertiger Geste, der Import kostet also keine Zeit.
         # -------------------------------------------------------------------
-        from GestureRecognition.labeling import _normalize, _add_velocity
+        # Wir benutzen genau dieselbe Funktion wie das Training (_to_features).
+        # So bekommt das Modell live die gleichen Zahlen wie beim Lernen.
+        from GestureRecognition.labeling import _to_features
 
-        # 1) Aus den gesammelten Punkten (deque) ein numpy-Array (N, 2) machen.
-        #    Jede Zeile ist eine (x, y)-Fingerposition in Bildkoordinaten [0, 1].
+        # 1) Aus den gesammelten Punkten eine Liste von (x, y) machen.
         trajectory = np.array(list(self.buffer), dtype=float)
 
-        # 2) Normalisieren: Mittelpunkt abziehen und auf den Einheitskreis skalieren.
-        #    Dadurch ist es egal, WO im Bild und WIE GROSS die Geste gemalt wurde.
-        trajectory = _normalize(trajectory)
-
-        # 3) Geschwindigkeit als dritte Spalte anhaengen -> (x, y, velocity).
-        #    velocity = Abstand zum vorherigen Frame; der erste Frame bekommt 0.0.
-        features = _add_velocity(trajectory)
+        # 2) In das fertige Format bringen: gleich viele Punkte + normalisieren
+        #    + Geschwindigkeit -> (x, y, geschwindigkeit) pro Punkt.
+        features = _to_features(trajectory)
 
         # 4) Puffer leeren, damit die naechste Geste sauber von vorne beginnt.
         self.buffer.clear()

--- a/GestureRecognition/visualization.py
+++ b/GestureRecognition/visualization.py
@@ -12,6 +12,7 @@ from GestureRecognition.labeling import (
     _extract_trajectory,
     _is_outlier,
     _normalize,
+    _to_features,
     clean_recordings,
     dataset_building,
 )
@@ -255,8 +256,7 @@ def _load_by_person(
                 continue
             if _is_outlier(traj, max_jump):
                 continue
-            traj = _normalize(traj)
-            traj = _add_velocity(traj)
+            traj = _to_features(traj)  # resample + normalize + velocity (wie dataset_building)
             if np.isnan(traj).any():  # gleicher NaN-Skip wie dataset_building
                 continue
 

--- a/train.py
+++ b/train.py
@@ -61,7 +61,7 @@ def train(
     recordings_dir="recordings",
     model_path="data/hmm.pkl",
     dataset_path="data/dataset.pkl",
-    n_components=4,
+    n_components=8,
     use_grid_search=False,
     test_size=0.2,
     random_state=42,
@@ -144,8 +144,8 @@ def main():
         help="Zielpfad fuer den erzeugten Datensatz (Standard: data/dataset.pkl)",
     )
     parser.add_argument(
-        "--n-components", type=int, default=4,
-        help="Anzahl Zustaende pro HMM (Standard: 4)",
+        "--n-components", type=int, default=8,
+        help="Anzahl Zustaende pro HMM (Standard: 8)",
     )
     parser.add_argument(
         "--grid-search", action="store_true",


### PR DESCRIPTION
Problem: Personen zeichnen unterschiedlich schnell (26 vs 70 Frames/Geste). Das verzerrt Geschwindigkeits-Feature + Sequenzlaenge und kostet Accuracy / Personen-Robustheit.

Fix (eine geteilte Quelle, Training UND Live identisch):
- labeling._to_features(): resample auf feste Laenge (RESAMPLE_LENGTH=48) ->
  normalize -> velocity. Genutzt von clean_recordings, _load_by_person UND dem
  Live-Preprocessor (process_trajectory) -> Training und Inferenz laufen nie
  auseinander (Live-Feature-Form fuer beliebige Puffergroesse verifiziert: (48,3)).
- HMMClassifier + train.py: n_components 4 -> 8 (modelliert Gestenphasen feiner).

Gemessen (evaluate_classifier, alle Personen): Standard-Accuracy 71.9% -> 89.6%, Neue-Person 59.2% -> 60.8%. Alle 5 Tests gruen.