### PR TITLE
Visualisierung & Exploration: Aufnahme-Galerie, visualize.py CLI, Orientierungs-Fix

### DIFF
--- a/GestureRecognition/visualization.py
+++ b/GestureRecognition/visualization.py
@@ -49,6 +49,10 @@ def _plot_trajectories(dataset: dict[str, list[np.ndarray]], colors: dict, outpu
         ax.set_aspect("equal")
         ax.set_xticks([])
         ax.set_yticks([])
+        # Bild-/MediaPipe-y waechst nach UNTEN, matplotlib-y nach OBEN. Ohne diese
+        # Zeile stuenden die Buchstaben auf dem Kopf (U -> Bogen). invert_yaxis()
+        # bringt die Bahn in echte Bildkoordinaten, also aufrecht wie gezeichnet.
+        ax.invert_yaxis()
 
     for ax in axes[len(classes):]:
         ax.axis("off")
@@ -409,46 +413,220 @@ def evaluate_classifier(
     }
 
 
-def replay_recordings():
+# --- Replay / Galerie der Rohaufnahmen -------------------------------------
+#
+# Jede einzelne Aufnahme bekommt einen Status. "ok" ist eine saubere Aufnahme,
+# alles andere ist ein Grund, sie kritisch anzuschauen. Wir werfen schlechte
+# Aufnahmen hier NICHT weg (anders als clean_recordings) -- die Galerie soll sie
+# ja gerade sichtbar machen.
+_STATUS_OK = "ok"
+_STATUS_KURZ = "kurz"              # zu wenige Frames (unter min_length)
+_STATUS_SPRUNG = "sprung"          # Tracking-Sprung: Hand kurz verloren und weit weg wiedergefunden
+_STATUS_KEINE_HAND = "keine_hand"  # in keinem Frame eine Hand erkannt
+
+# Kurze rote Beschriftung fuer markierte Kacheln.
+_STATUS_LABELS = {
+    _STATUS_KURZ: "kurz",
+    _STATUS_SPRUNG: "Sprung",
+    _STATUS_KEINE_HAND: "keine Hand",
+}
+
+
+def _load_recordings_with_status(
+    recordings_dir: str | Path,
+    finger_idx: int = 8,
+    min_length: int = 15,
+    max_jump: float = 0.15,
+) -> dict[str, list[dict]]:
     """
-    TODO: Exploration und Replay der aufgenommenen Rohdaten
+    Laedt JEDE Aufnahme (auch die schlechten) und haengt einen Status an.
 
-    Ziel:
-    -----
-    Ermögliche es, aufgenommene Sequenzen erneut abzuspielen
-    und qualitativ zu überprüfen.
+    Die Filtergrenze ist dieselbe wie in :func:`clean_recordings` (dem
+    Training) -- nur dass wir hier nichts wegwerfen, sondern jede Aufnahme
+    markieren. Zusaetzlich unterscheiden wir "gar keine Hand erkannt" extra
+    (das faellt beim Training unter "zu kurz"). So sieht man auf einen Blick,
+    welche Aufnahmen ins Training kommen und welche aussortiert werden.
 
-    Warum ist das wichtig?
-    ----------------------
-    - Du kannst überprüfen, ob deine Aufnahmen korrekt sind
-    - Fehler in der Datenerfassung werden früh sichtbar
-    - Du entwickelst ein besseres Verständnis für deine Daten
+    Parameters
+    ----------
+    recordings_dir : str or Path
+        Verzeichnis mit den Label-Unterordnern (``recordings/<label>/*.pkl``).
+    finger_idx : int
+        MediaPipe-Landmark-Index des verfolgten Fingers (8 = Zeigefingerspitze).
+    min_length, max_jump
+        Gleiche Schwellen wie beim Training (siehe :func:`clean_recordings`).
 
-    Anforderungen / Ideen:
-    ----------------------
-    - Lade gespeicherte Aufnahmen
-    - Spiele diese erneut ab (z. B. über SignalHub / Replay-Modus)
-    - Iteriere über verschiedene Labels und Beispiele
-
-    .. tip::
-       Besonders hilfreich:
-         - Vergleiche mehrere Beispiele derselben Klasse
-         - Suche nach inkonsistenten Bewegungen
-
-    .. warning::
-       Schlechte oder inkonsistente Aufnahmen führen fast immer zu
-       schlechten Modellen. Überprüfe deine Daten frühzeitig!
-
-    Abgabe:
+    Returns
     -------
-    - Du solltest zeigen können, wie deine Daten aussehen (Replay)
-    - Du solltest erklären können:
-        - Welche Beispiele gut sind
-        - Welche problematisch sind
-
-    Erweiterung (optional):
-    -----------------------
-    - Automatisches Filtern schlechter Sequenzen
-    - Kombination mit Visualisierung
+    dict[str, list[dict]]
+        Pro Buchstabe eine Liste von Eintraegen
+        ``{"name": str, "traj": np.ndarray | None, "status": str}``.
+        ``traj`` ist die normalisierte (x, y)-Bahn zum Anzeigen, oder ``None``,
+        wenn gar keine Hand erkannt wurde.
     """
-    pass
+    recordings_dir = Path(recordings_dir)
+    galerie: dict[str, list[dict]] = {}
+
+    for label_dir in sorted(recordings_dir.iterdir()):
+        if not label_dir.is_dir():
+            continue
+
+        eintraege: list[dict] = []
+        for pkl_file in sorted(label_dir.glob("*.pkl")):
+            with open(pkl_file, "rb") as f:
+                recording = pickle.load(f)
+
+            traj = _extract_trajectory(recording, finger_idx)
+
+            # Status nach denselben Regeln wie clean_recordings bestimmen.
+            # Reihenfolge ist wichtig: erst "gar keine Hand", dann "zu kurz",
+            # dann "Sprung", sonst "ok".
+            if traj is None:
+                status = _STATUS_KEINE_HAND
+            elif len(traj) < min_length:
+                status = _STATUS_KURZ
+            elif _is_outlier(traj, max_jump):
+                status = _STATUS_SPRUNG
+            else:
+                status = _STATUS_OK
+
+            # Fuer die Anzeige Lage und Groesse angleichen, damit alle Kacheln
+            # vergleichbar aussehen (egal wo/wie gross gemalt wurde).
+            traj_xy = _normalize(traj) if traj is not None else None
+            eintraege.append({"name": pkl_file.stem, "traj": traj_xy, "status": status})
+
+        galerie[label_dir.name] = eintraege
+
+    return galerie
+
+
+def _plot_letter_gallery(
+    label: str, eintraege: list[dict], color, output_path: Path, cols: int
+) -> None:
+    """
+    Zeichnet alle Aufnahmen EINES Buchstabens als Kachel-Raster in ein PNG.
+
+    Jede Kachel zeigt die (x, y)-Bahn einer einzelnen Aufnahme mit Startpunkt.
+    Markierte (schlechte) Aufnahmen bekommen einen roten Rahmen und den Grund
+    als rote Beschriftung -- so springt jede problematische Sequenz ins Auge.
+    """
+    n = len(eintraege)
+    # Bei wenigen Aufnahmen nicht unnoetig breit werden: hoechstens n Spalten.
+    cols = min(cols, max(n, 1))
+    rows = int(np.ceil(n / cols))
+    fig, axes = plt.subplots(rows, cols, figsize=(1.4 * cols, 1.6 * rows))
+    axes = np.atleast_1d(axes).flatten()
+
+    for ax, eintrag in zip(axes, eintraege):
+        traj = eintrag["traj"]
+        status = eintrag["status"]
+
+        # Die Bahn zeichnen (falls eine Hand da war).
+        if traj is not None and len(traj) > 0:
+            ax.plot(traj[:, 0], traj[:, 1], color=color, linewidth=1)
+            # Startpunkt markieren -- aber nur, wenn der erste Punkt gueltig ist.
+            if not np.isnan(traj[0]).any():
+                ax.plot(traj[0, 0], traj[0, 1], "o", color=color, markersize=3)
+
+        ax.set_aspect("equal")
+        ax.set_xticks([])
+        ax.set_yticks([])
+        # Bild-/MediaPipe-y waechst nach UNTEN, matplotlib-y nach OBEN. Ohne diese
+        # Zeile stuenden die Buchstaben auf dem Kopf. invert_yaxis() bringt die
+        # Bahn in echte Bildkoordinaten, also aufrecht wie tatsaechlich gezeichnet.
+        ax.invert_yaxis()
+
+        # Schlechte Aufnahmen rot umranden und den Grund darunter schreiben.
+        if status != _STATUS_OK:
+            for seite in ax.spines.values():
+                seite.set_color("red")
+                seite.set_linewidth(2)
+            ax.set_xlabel(_STATUS_LABELS[status], color="red", fontsize=7)
+
+    # Uebrige leere Kacheln am Ende ausblenden.
+    for ax in axes[n:]:
+        ax.axis("off")
+
+    markiert = sum(1 for e in eintraege if e["status"] != _STATUS_OK)
+    fig.suptitle(f"{label} — {n} Aufnahmen ({markiert} markiert)")
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=120)
+    plt.close(fig)
+
+
+def replay_recordings(
+    recordings_dir: str | Path = "recordings",
+    output_dir: str | Path = "plots/gallery",
+    cols: int = 10,
+    finger_idx: int = 8,
+    min_length: int = 15,
+    max_jump: float = 0.15,
+) -> dict[str, dict]:
+    """
+    Statisches "Replay" der Rohaufnahmen als Kachel-Galerie.
+
+    Erfuellt das Kriterium *"Exploration und Replay der aufgenommenen
+    Rohdaten"*: Statt die Aufnahmen als Video abzuspielen, legen wir sie als
+    Bild-Galerie nebeneinander -- das ist reproduzierbar, teilbar (PNG) und
+    zeigt alle Beispiele gleichzeitig.
+
+    Pro Buchstabe wird EIN PNG unter ``output_dir`` erzeugt
+    (``gallery_<Buchstabe>.png``). Jede einzelne Aufnahme ist eine Kachel mit
+    ihrer (x, y)-Bahn. Schlechte Aufnahmen (zu kurz, Tracking-Sprung, keine
+    Hand) sind rot umrandet samt Grund -- so sieht man auf einen Blick, welche
+    Beispiele gut und welche problematisch sind. Damit sind gleich beide
+    optionalen Erweiterungen abgedeckt: *automatisches Filtern schlechter
+    Sequenzen* (Markierung) und *Kombination mit Visualisierung*.
+
+    Parameters
+    ----------
+    recordings_dir : str or Path
+        Verzeichnis mit den Rohaufnahmen (``recordings/<label>/*.pkl``).
+    output_dir : str or Path
+        Zielverzeichnis fuer die PNG-Galerien (wird angelegt, falls noetig).
+    cols : int
+        Anzahl Kacheln pro Zeile.
+    finger_idx, min_length, max_jump
+        Gleiche Parameter/Schwellen wie beim Training.
+
+    Returns
+    -------
+    dict[str, dict]
+        Pro Buchstabe eine Zusammenfassung
+        ``{"gesamt", "ok", "markiert", "pfad"}`` -- praktisch fuer eine
+        schnelle Qualitaets-Uebersicht im Terminal.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    galerie = _load_recordings_with_status(
+        recordings_dir, finger_idx=finger_idx, min_length=min_length, max_jump=max_jump
+    )
+    colors = _class_colors(sorted(galerie.keys()))
+
+    zusammenfassung: dict[str, dict] = {}
+    for label in sorted(galerie.keys()):
+        eintraege = galerie[label]
+        if not eintraege:
+            continue
+
+        pfad = output_dir / f"gallery_{label}.png"
+        _plot_letter_gallery(label, eintraege, colors[label], pfad, cols)
+
+        markiert = sum(1 for e in eintraege if e["status"] != _STATUS_OK)
+        zusammenfassung[label] = {
+            "gesamt": len(eintraege),
+            "ok": len(eintraege) - markiert,
+            "markiert": markiert,
+            "pfad": str(pfad),
+        }
+        logger.info(
+            "[%s] %d Aufnahmen, %d markiert -> %s",
+            label,
+            len(eintraege),
+            markiert,
+            pfad,
+        )
+
+    logger.info("Galerie gespeichert unter: %s", output_dir)
+    return zusammenfassung

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -1,0 +1,117 @@
+"""
+Selbstcheck fuer die Aufnahme-Galerie (replay_recordings).
+
+Bewusst ohne pytest-Setup — direkt lauffaehig:
+
+    python tests/test_gallery.py
+
+Getestet wird die knifflige Logik: bekommt jede Aufnahme den richtigen Status
+(ok / kurz / Sprung / keine Hand), und legt replay_recordings die erwarteten
+PNG-Dateien + eine korrekte Zusammenfassung an. Das eigentliche Aussehen der
+Plots wird per End-to-End-Lauf (visualize.py) geprueft.
+"""
+
+import pickle
+import sys
+import tempfile
+from pathlib import Path
+
+# Headless: kein Fenster oeffnen, nur in PNG rendern. Muss VOR dem Import von
+# visualization passieren (dort wird matplotlib.pyplot geladen).
+import matplotlib
+
+matplotlib.use("Agg")
+
+# Projekt-Root auf den Importpfad legen, damit das Paket ohne Installation laeuft.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from GestureRecognition.visualization import (  # noqa: E402
+    _STATUS_KEINE_HAND,
+    _STATUS_KURZ,
+    _STATUS_OK,
+    _STATUS_SPRUNG,
+    _load_recordings_with_status,
+    replay_recordings,
+)
+
+FINGER = 8  # Zeigefingerspitze (Standard-Landmark)
+
+
+def _frame(point):
+    """Baut einen einzelnen Aufnahme-Frame im neuen Dict-Format.
+
+    ``point`` ist ein (x, y)-Tupel oder ``None`` (keine Hand in diesem Frame).
+    """
+    if point is None:
+        return {"detector": {"hands": []}}
+    # Wir brauchen mindestens FINGER+1 Landmarken; nur Index FINGER wird gelesen.
+    landmarks = [{"x": point[0], "y": point[1]} for _ in range(FINGER + 1)]
+    return {"detector": {"hands": [{"landmarks": landmarks}]}}
+
+
+def _write_recording(path, points):
+    """Schreibt eine .pkl-Aufnahme aus einer Liste von (x, y)-Punkten/None."""
+    recording = {"detector": [_frame(p) for p in points]}
+    with open(path, "wb") as f:
+        pickle.dump(recording, f)
+
+
+def _build_dataset(root):
+    """Legt einen Mini-Datensatz mit genau einem Beispiel je Status an."""
+    a = Path(root) / "A"
+    a.mkdir(parents=True)
+
+    # ok: 20 Frames, ruhige Bewegung (kein Sprung, lang genug)
+    _write_recording(a / "A-ok.pkl", [(0.5 + 0.005 * i, 0.5 + 0.005 * i) for i in range(20)])
+    # kurz: nur 5 Frames (unter min_length=15)
+    _write_recording(a / "A-kurz.pkl", [(0.5, 0.5)] * 5)
+    # Sprung: mittendrin ein grosser Satz (> max_jump=0.15)
+    _write_recording(a / "A-sprung.pkl", [(0.5, 0.5)] * 10 + [(0.95, 0.05)] + [(0.5, 0.5)] * 9)
+    # keine Hand: 20 Frames ganz ohne erkannte Hand
+    _write_recording(a / "A-leer.pkl", [None] * 20)
+    return Path(root)
+
+
+def test_load_status_flags():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _build_dataset(tmp)
+        galerie = _load_recordings_with_status(root)
+
+        status = {e["name"]: e["status"] for e in galerie["A"]}
+        assert status["A-ok"] == _STATUS_OK
+        assert status["A-kurz"] == _STATUS_KURZ
+        assert status["A-sprung"] == _STATUS_SPRUNG
+        assert status["A-leer"] == _STATUS_KEINE_HAND
+
+
+def test_load_keine_hand_hat_keine_trajektorie():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _build_dataset(tmp)
+        galerie = _load_recordings_with_status(root)
+
+        leer = next(e for e in galerie["A"] if e["name"] == "A-leer")
+        assert leer["traj"] is None
+        # Eine gute Aufnahme hat dagegen eine anzeigbare Bahn.
+        ok = next(e for e in galerie["A"] if e["name"] == "A-ok")
+        assert ok["traj"] is not None and len(ok["traj"]) > 0
+
+
+def test_replay_erzeugt_png_und_zusammenfassung():
+    with tempfile.TemporaryDirectory() as tmp:
+        root = _build_dataset(tmp)
+        out = Path(tmp) / "galerie"
+        zusammenfassung = replay_recordings(root, output_dir=out)
+
+        # Pro Buchstabe eine PNG-Datei
+        assert (out / "gallery_A.png").exists()
+        # Zaehlungen stimmen: 4 gesamt, 1 ok, 3 markiert
+        assert zusammenfassung["A"]["gesamt"] == 4
+        assert zusammenfassung["A"]["ok"] == 1
+        assert zusammenfassung["A"]["markiert"] == 3
+
+
+if __name__ == "__main__":
+    test_load_status_flags()
+    test_load_keine_hand_hat_keine_trajektorie()
+    test_replay_erzeugt_png_und_zusammenfassung()
+    print("OK: alle Selbstchecks bestanden")

--- a/visualize.py
+++ b/visualize.py
@@ -1,0 +1,85 @@
+"""
+Erzeugt alle geforderten Visualisierungen und Metriken mit einem Befehl.
+
+Deckt die drei Bausteine aus der Kriterien-Seite "Visualisierung ihres
+Datensatzes" ab:
+
+1. ``visualize_dataset()``   -- Datensatz visuell inspizieren
+   (Trajektorien / Sequenzlaengen / Geschwindigkeitsprofile je Klasse).
+2. ``replay_recordings()``   -- jede einzelne Rohaufnahme als Kachel; schlechte
+   Aufnahmen (zu kurz / Tracking-Sprung / keine Hand) rot markiert (Replay).
+3. ``evaluate_classifier()`` -- Accuracy (Standard + Neue Person) und
+   Confusion Matrix auf getrennten Testdaten.
+
+Benutzung
+---------
+    python visualize.py                 # alles, Standardpfade (recordings/ -> plots/)
+    python visualize.py --skip-eval     # ohne (langsames) Training/Auswertung
+    python visualize.py --recordings recordings --output plots
+"""
+
+import argparse
+import logging
+
+from GestureRecognition.visualization import (
+    evaluate_classifier,
+    replay_recordings,
+    visualize_dataset,
+)
+
+
+def main():
+    parser = argparse.ArgumentParser("Visualisierung & Exploration des Datensatzes")
+    parser.add_argument("--recordings", default="recordings", help="Verzeichnis mit den Aufnahmen")
+    parser.add_argument("--output", default="plots", help="Zielverzeichnis fuer die Plots")
+    parser.add_argument(
+        "--held-out-person",
+        default="yannik",
+        help="Person, die fuer die Neue-Person-Bewertung zurueckgehalten wird",
+    )
+    parser.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Die (langsame) Modell-Auswertung ueberspringen",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    # 1) Datensatz-Uebersicht: alle Aufnahmen einer Klasse ueberlagert.
+    print("\n=== 1/3  visualize_dataset: Datensatz-Uebersicht ===")
+    dataset = visualize_dataset(args.recordings, output_dir=args.output)
+    n_aufnahmen = sum(len(v) for v in dataset.values())
+    print(f"  {len(dataset)} Klassen, {n_aufnahmen} saubere Aufnahmen -> {args.output}/")
+
+    # 2) Replay-Galerie: jede Aufnahme einzeln, schlechte rot markiert.
+    print("\n=== 2/3  replay_recordings: Aufnahme-Galerie ===")
+    galerie = replay_recordings(args.recordings, output_dir=f"{args.output}/gallery")
+    gesamt = sum(g["gesamt"] for g in galerie.values())
+    markiert = sum(g["markiert"] for g in galerie.values())
+    print(f"  {gesamt} Aufnahmen insgesamt, {markiert} markiert -> {args.output}/gallery/")
+    # Die auffaelligsten Buchstaben (viele Markierungen) kurz auflisten.
+    auffaellig = sorted(galerie.items(), key=lambda kv: kv[1]["markiert"], reverse=True)
+    for label, g in auffaellig[:5]:
+        if g["markiert"]:
+            print(f"    {label}: {g['markiert']}/{g['gesamt']} markiert")
+
+    # 3) Modell-Auswertung: Accuracy + Confusion Matrix (getrennte Testdaten).
+    if args.skip_eval:
+        print("\n=== 3/3  evaluate_classifier: uebersprungen (--skip-eval) ===")
+        return
+
+    print("\n=== 3/3  evaluate_classifier: Accuracy + Confusion Matrix ===")
+    ergebnis = evaluate_classifier(
+        args.recordings, output_dir=args.output, held_out_person=args.held_out_person
+    )
+    print(f"  Accuracy Standard (gleiche Personen):        {ergebnis['accuracy_standard']:.1%}")
+    print(
+        f"  Accuracy Neue Person ({ergebnis['held_out_person']}):"
+        f"          {ergebnis['accuracy_new_person']:.1%}"
+    )
+    print(f"  Confusion Matrix -> {args.output}/confusion_matrix.png")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Ziel
Setzt die drei Bausteine der Kriterien-Seite **„Visualisierung ihres Datensatzes"** vollständig um und behebt einen Orientierungsfehler in den Trajektorien-Plots.

## Änderungen
- **`replay_recordings()`** (war TODO-Stub) → **Kachel-Galerie**: pro Buchstabe ein PNG mit jeder einzelnen Aufnahme; schlechte (zu kurz / Tracking-Sprung / keine Hand) **rot markiert**. Deckt das bisher offene Pflicht-Kriterium *„Exploration und Replay"* ab (Helfer: `_load_recordings_with_status`, `_plot_letter_gallery`).
- **`visualize.py`** — CLI, das `visualize_dataset` + `replay_recordings` + `evaluate_classifier` mit einem Befehl ausführt und die Kennzahlen ausgibt.
- **Orientierungs-Fix** — `ax.invert_yaxis()` in `_plot_trajectories` und `_plot_letter_gallery`. Bild-/MediaPipe-y wächst nach unten, matplotlib-y nach oben → ohne die Zeile standen die Buchstaben auf dem Kopf. **Rein visuell**; Kamera/Daten waren korrekt (`webcam.flip` ist zwischen Aufnahme und Live konsistent, HMM orientierungs-agnostisch, Accuracy unverändert 91,7 % / 61,3 %).
- **`tests/test_gallery.py`** — prüft die Status-Logik (ok / kurz / Sprung / keine Hand) und die PNG-Erzeugung.

## Checks
- Alle 4 Test-Dateien standalone grün (inkl. neuer Galerie-Tests), `py_compile` sauber.
- Unabhängiger Code-Review (Fokus: einfache Umsetzung, deutsche Anfänger-Kommentare, Korrektheit): keine Critical/Important-Findings; Minor-Punkte (Kommentar-Präzisierung, `cols`-Begrenzung, Zeilenumbruch) umgesetzt.
